### PR TITLE
BRIN operator class

### DIFF
--- a/h3/sql/install/13-opclass_brin.sql
+++ b/h3/sql/install/13-opclass_brin.sql
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Bytes & Brains
+ * Copyright 2019 Bytes & Brains
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,9 @@
  * limitations under the License.
  */
 
--- complain if script is sourced in psql, rather than via CREATE EXTENSION
-\echo Use "ALTER EXTENSION h3 UPDATE TO 'unreleased'" to load this file. \quit
-
-CREATE OR REPLACE FUNCTION
-    h3_cells_to_multi_polygon_wkb(h3index[]) RETURNS bytea
-AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
-    h3_cells_to_multi_polygon_wkb(h3index[])
-IS 'Create a LinkedGeoPolygon describing the outline(s) of a set of hexagons, converts to EWKB.
-
-Splits polygons when crossing 180th meridian.';
-
-
 -- BRIN operator class
+
+--@ internal
 CREATE OPERATOR CLASS brin_h3index_ops DEFAULT FOR TYPE h3index USING brin AS
     OPERATOR  1  <  ,
     OPERATOR  2  <= ,
@@ -38,4 +28,3 @@ CREATE OPERATOR CLASS brin_h3index_ops DEFAULT FOR TYPE h3index USING brin AS
     FUNCTION  3  brin_minmax_multi_consistent,
     FUNCTION  4  brin_minmax_multi_union,
     FUNCTION 11  brin_minmax_multi_distance_int8;
-

--- a/h3/test/expected/opclass_brin.out
+++ b/h3/test/expected/opclass_brin.out
@@ -1,0 +1,14 @@
+\pset tuples_only on
+\set string '\'801dfffffffffff\''
+\set hexagon ':string::h3index'
+CREATE TABLE h3_test_brin (hex h3index PRIMARY KEY);
+INSERT INTO h3_test_brin (hex) SELECT * FROM h3_get_res_0_cells();
+CREATE INDEX h3_brin ON h3_test_brin USING brin (hex);
+--
+-- Test BRIN operator class
+--
+SELECT hex = :hexagon FROM (
+  SELECT hex FROM h3_test_brin WHERE hex = :hexagon
+) q;
+ t
+

--- a/h3/test/sql/opclass_brin.sql
+++ b/h3/test/sql/opclass_brin.sql
@@ -1,0 +1,13 @@
+\pset tuples_only on
+\set string '\'801dfffffffffff\''
+\set hexagon ':string::h3index'
+
+CREATE TABLE h3_test_brin (hex h3index PRIMARY KEY);
+INSERT INTO h3_test_brin (hex) SELECT * FROM h3_get_res_0_cells();
+CREATE INDEX h3_brin ON h3_test_brin USING brin (hex);
+--
+-- Test BRIN operator class
+--
+SELECT hex = :hexagon FROM (
+  SELECT hex FROM h3_test_brin WHERE hex = :hexagon
+) q;


### PR DESCRIPTION
BRIN operator class for `h3index` using built-in `minmax_multi` functions.

I have briefly tested `minmax` and `minmax_multi` variants and concluded that `minmax_multi` can be useful when records are added in large enough groups of related indices (~1K--10K, also depending on record size and `values_per_range` parameter), where `minmax` doesn't work.

Execution time reported by `psql`.
(This particular result seem a bit lucky for `minmax_multi` performance, I also got ~40 ms for SELECTs with newly generated data.)
```
CREATE TABLE myh3 (id SERIAL PRIMARY KEY, h3 h3index);

WITH
    geom AS (
        SELECT 'SRID=4326;polygon((0 0, 0 1, 1 1, 1 0, 0 0))'::geometry AS geom),
    samples AS (
        SELECT lon, lat
        FROM
            generate_series(-180, 170, 10) AS lon,
            generate_series(-80, 80, 10) AS lat
        ORDER BY RANDOM()),
    geoms AS (
        SELECT ST_Translate(g.geom, s.lon, s.lat) AS geom
        FROM geom AS g, samples AS s),
    h3 AS (
        SELECT h3_polygon_to_cells(geom, 8) AS h3
        FROM geoms)
INSERT INTO myh3 (h3) SELECT h3 FROM h3;

SELECT COUNT(*) FROM myh3;
-- 6899730

CREATE INDEX myh3_brin ON myh3 USING brin(h3);
-- minmax (ms)      : 593.930, 677.878, 597.658, 595.835, 593.232
-- minmax-multi (ms): 1172.250, 1161.281, 1170.491, 1175.545, 1164.199 

SELECT pg_table_size('myh3_brin');
-- minmax      : 57344
-- minmax-multi: 131072

SELECT COUNT(*) FROM myh3 WHERE h3 BETWEEN '88754e64dbfffff'::h3index AND '88754e66b7fffff'::h3index;
-- no index (ms)     : 98.909, 101.809, 104.823, 106.691, 99.582
-- minmax (ms)       : 133.110, 135.694, 132.614, 136.596
-- minmax-multi (ms) : 9.851, 7.697, 9.143, 8.591, 9.386

SELECT * FROM myh3 WHERE h3 = '88754e64dbfffff'::h3index;
-- no index (ms)    : 97.629, 95.563, 96.977, 98.156, 98.156
-- minmax (ms)      : 132.934, 137.827, 123.559, 124.303, 129.186
-- minmax-multi (ms): 10.463, 14.984, 9.158, 15.276, 14.462
```