### PR TITLE
BRIN operator class

### DIFF
--- a/h3/sql/install/13-opclass_brin.sql
+++ b/h3/sql/install/13-opclass_brin.sql
@@ -23,7 +23,7 @@ CREATE OPERATOR CLASS brin_h3index_ops DEFAULT FOR TYPE h3index USING brin AS
     OPERATOR  3   = ,
     OPERATOR  4  >= ,
     OPERATOR  5  >  ,
-    FUNCTION  1  brin_minmax_opcinfo,
-    FUNCTION  2  brin_minmax_add_value,
-    FUNCTION  3  brin_minmax_consistent,
-    FUNCTION  4  brin_minmax_union;
+    FUNCTION  1  brin_minmax_opcinfo(internal),
+    FUNCTION  2  brin_minmax_add_value(internal, internal, internal, internal),
+    FUNCTION  3  brin_minmax_consistent(internal, internal, internal),
+    FUNCTION  4  brin_minmax_union(internal, internal, internal);

--- a/h3/sql/install/13-opclass_brin.sql
+++ b/h3/sql/install/13-opclass_brin.sql
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Bytes & Brains
+ * Copyright 2019 Bytes & Brains
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,9 @@
  * limitations under the License.
  */
 
--- complain if script is sourced in psql, rather than via CREATE EXTENSION
-\echo Use "ALTER EXTENSION h3 UPDATE TO 'unreleased'" to load this file. \quit
-
-CREATE OR REPLACE FUNCTION
-    h3_cells_to_multi_polygon_wkb(h3index[]) RETURNS bytea
-AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
-    h3_cells_to_multi_polygon_wkb(h3index[])
-IS 'Create a LinkedGeoPolygon describing the outline(s) of a set of hexagons, converts to EWKB.
-
-Splits polygons when crossing 180th meridian.';
-
-
 -- BRIN operator class
+
+--@ internal
 CREATE OPERATOR CLASS brin_h3index_ops DEFAULT FOR TYPE h3index USING brin AS
     OPERATOR  1  <  ,
     OPERATOR  2  <= ,
@@ -37,4 +27,3 @@ CREATE OPERATOR CLASS brin_h3index_ops DEFAULT FOR TYPE h3index USING brin AS
     FUNCTION  2  brin_minmax_add_value,
     FUNCTION  3  brin_minmax_consistent,
     FUNCTION  4  brin_minmax_union;
-

--- a/h3/sql/updates/h3--4.0.2--unreleased.sql
+++ b/h3/sql/updates/h3--4.0.2--unreleased.sql
@@ -33,8 +33,8 @@ CREATE OPERATOR CLASS brin_h3index_ops DEFAULT FOR TYPE h3index USING brin AS
     OPERATOR  3   = ,
     OPERATOR  4  >= ,
     OPERATOR  5  >  ,
-    FUNCTION  1  brin_minmax_opcinfo,
-    FUNCTION  2  brin_minmax_add_value,
-    FUNCTION  3  brin_minmax_consistent,
-    FUNCTION  4  brin_minmax_union;
+    FUNCTION  1  brin_minmax_opcinfo(internal),
+    FUNCTION  2  brin_minmax_add_value(internal, internal, internal, internal),
+    FUNCTION  3  brin_minmax_consistent(internal, internal, internal),
+    FUNCTION  4  brin_minmax_union(internal, internal, internal);
 

--- a/h3/test/expected/opclass_brin.out
+++ b/h3/test/expected/opclass_brin.out
@@ -1,0 +1,14 @@
+\pset tuples_only on
+\set string '\'801dfffffffffff\''
+\set hexagon ':string::h3index'
+CREATE TABLE h3_test_brin (hex h3index PRIMARY KEY);
+INSERT INTO h3_test_brin (hex) SELECT * FROM h3_get_res_0_cells();
+CREATE INDEX h3_brin ON h3_test_brin USING brin (hex);
+--
+-- Test BRIN operator class
+--
+SELECT hex = :hexagon FROM (
+  SELECT hex FROM h3_test_brin WHERE hex = :hexagon
+) q;
+ t
+

--- a/h3/test/sql/opclass_brin.sql
+++ b/h3/test/sql/opclass_brin.sql
@@ -1,0 +1,13 @@
+\pset tuples_only on
+\set string '\'801dfffffffffff\''
+\set hexagon ':string::h3index'
+
+CREATE TABLE h3_test_brin (hex h3index PRIMARY KEY);
+INSERT INTO h3_test_brin (hex) SELECT * FROM h3_get_res_0_cells();
+CREATE INDEX h3_brin ON h3_test_brin USING brin (hex);
+--
+-- Test BRIN operator class
+--
+SELECT hex = :hexagon FROM (
+  SELECT hex FROM h3_test_brin WHERE hex = :hexagon
+) q;


### PR DESCRIPTION
BRIN index can be useful for data sorted by `h3index`.

```
CREATE TABLE myh3 (
    id SERIAL PRIMARY KEY,
    h3 h3index);

WITH
    geom AS (
        SELECT 'SRID=4326;polygon((0 0, 0 1, 1 1, 1 0, 0 0))'::geometry AS geom),
    samples AS (
        SELECT lon, lat
        FROM
            generate_series(-180, 170, 10) AS lon,
            generate_series(-80, 80, 10) AS lat),
    geoms AS (
        SELECT ST_Translate(g.geom, s.lon, s.lat) AS geom
        FROM geom AS g, samples AS s),
    h3 AS (
        SELECT h3_polygon_to_cells(geom, 8) AS h3
        FROM geoms)
INSERT INTO myh3 (h3)
SELECT h3 FROM h3 ORDER BY h3;
-- 6899730

SELECT COUNT(*) FROM myh3 WHERE h3 BETWEEN '88754e64dbfffff'::h3index AND '88754e66b7fffff'::h3index;
-- 136.724 ms

CREATE INDEX myh3_brin ON myh3 USING brin(h3);


SELECT COUNT(*) FROM myh3 WHERE h3 BETWEEN '88754e64dbfffff'::h3index AND '88754e66b7fffff'::h3index;
-- 5.240 ms
```