### PR TITLE
Rename h3index_ops for btree and hash to match builtins

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -20,6 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Cache Cargo
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-cargo-2022
+
       - name: Install pg_validate_extupgrade
         run: cargo install --locked --git https://github.com/rjuju/pg_validate_extupgrade.git
 

--- a/h3/sql/install/11-opclass_btree.sql
+++ b/h3/sql/install/11-opclass_btree.sql
@@ -27,7 +27,7 @@ CREATE OR REPLACE FUNCTION h3index_sortsupport(internal)
 	LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 --@ internal
-CREATE OPERATOR CLASS btree_h3index_ops DEFAULT FOR TYPE h3index USING btree AS
+CREATE OPERATOR CLASS h3index_ops DEFAULT FOR TYPE h3index USING btree AS
     OPERATOR  1  <  ,
     OPERATOR  2  <= ,
     OPERATOR  3   = ,

--- a/h3/sql/install/12-opclass_hash.sql
+++ b/h3/sql/install/12-opclass_hash.sql
@@ -25,7 +25,7 @@ CREATE OR REPLACE FUNCTION h3index_hash_extended(h3index, int8) RETURNS int8
     AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 --@ internal
-CREATE OPERATOR CLASS hash_h3index_ops DEFAULT FOR TYPE h3index USING hash AS
+CREATE OPERATOR CLASS h3index_ops DEFAULT FOR TYPE h3index USING hash AS
     OPERATOR  1  = ,
     FUNCTION  1  h3index_hash(h3index),
     FUNCTION  2  h3index_hash_extended(h3index, int8);

--- a/h3/sql/updates/h3--4.0.2--4.0.3.sql
+++ b/h3/sql/updates/h3--4.0.2--4.0.3.sql
@@ -37,3 +37,9 @@ CREATE OPERATOR CLASS h3index_minmax_ops DEFAULT FOR TYPE h3index USING brin AS
     FUNCTION  2  brin_minmax_add_value(internal, internal, internal, internal),
     FUNCTION  3  brin_minmax_consistent(internal, internal, internal),
     FUNCTION  4  brin_minmax_union(internal, internal, internal);
+
+ALTER OPERATOR FAMILY btree_h3index_ops USING btree RENAME TO h3index_ops;
+ALTER OPERATOR CLASS  btree_h3index_ops USING btree RENAME TO h3index_ops;
+
+ALTER OPERATOR FAMILY hash_h3index_ops USING hash RENAME TO h3index_ops;
+ALTER OPERATOR CLASS  hash_h3index_ops USING hash RENAME TO h3index_ops;


### PR DESCRIPTION
This PR mostly exists to figure out if I am misunderstanding something, or if there is a bug in [rjuju/pg_validate/extupgrade](https://github.com/rjuju/pg_validate_extupgrade).

I have renamed the `h3index` operator families/classes using `btree` and `hash` to all be `h3index_ops`. That aligns with built-ins like `float8_ops` which share the same name across index methods.

My `pg_validate_extupgrade` test is failing, however, I'll try to figure out why.

Edit: Apparently, it only fails locally. I'll have to investigate.