### PR TITLE
Splitting cells by 180th meridian: polar polygon fix

### DIFF
--- a/h3/src/wkb_indexing.c
+++ b/h3/src/wkb_indexing.c
@@ -26,6 +26,13 @@
 
 #define SIGN(x) ((x < 0) ? -1 : (x > 0) ? 1 \
 										: 0)
+#define ABS_LAT_MAX (degsToRads(89.9999))
+
+#define SPLIT_ASSERT(condition, message)			\
+	ASSERT(										\
+		condition,									\
+		ERRCODE_EXTERNAL_ROUTINE_EXCEPTION,		\
+		message)
 
 PG_FUNCTION_INFO_V1(h3_cell_to_boundary_wkb);
 
@@ -34,12 +41,21 @@ static void
 			boundary_to_degs(CellBoundary * boundary);
 
 /* Checks if CellBoundary is crossed by antimeridian */
-static bool
-			boundary_crosses_180(const CellBoundary * boundary);
+static int
+			boundary_crosses_180_num(const CellBoundary * boundary);
 
 /* Splits CellBoundary by antimeridian (and 0 meridian around poles) */
 static void
 			boundary_split_180(const CellBoundary * boundary, CellBoundary * left, CellBoundary * right);
+
+/*
+  Creates a boundary for polar cells with additional points on an antimeridian.
+  The functions adds 2 points (with lon. 180 and -180) for intersection with
+  antimeridian and 2 points on antimeridian close to the pole.
+  This allows to better display polar cells in e.g. Mercator projection.
+ */
+static void
+			boundary_split_180_polar(const CellBoundary * boundary, CellBoundary * res);
 
 /* Finds the boundary of the index, converts to EWKB, splits the boundary by 180 meridian */
 Datum
@@ -48,14 +64,31 @@ h3_cell_to_boundary_wkb(PG_FUNCTION_ARGS)
 	H3Index		cell = PG_GETARG_H3INDEX(0);
 
 	H3Error		error;
-	bytea	   *wkb;
+	bytea		*wkb;
 	CellBoundary boundary;
+	int		crossNum;
 
 	error = cellToBoundary(cell, &boundary);
 	H3_ERROR(error, "cellToBoundary");
 
-	if (boundary_crosses_180(&boundary))
+	crossNum = boundary_crosses_180_num(&boundary);
+	if (crossNum == 0)
 	{
+		/* Cell is not crossed by antimeridian */
+		boundary_to_degs(&boundary);
+		wkb = boundary_to_wkb(&boundary);
+	}
+	else if (crossNum == 1)
+	{
+		/* Cell boundary is crossed by antimeridian once */
+		CellBoundary split;
+		boundary_split_180_polar(&boundary, &split);
+		boundary_to_degs(&split);
+		wkb = boundary_to_wkb(&split);
+	}
+	else
+	{
+		/* Crossed by antimeridian */
 		CellBoundary parts[2];
 
 		boundary_split_180(&boundary, &parts[0], &parts[1]);
@@ -63,11 +96,6 @@ h3_cell_to_boundary_wkb(PG_FUNCTION_ARGS)
 		boundary_to_degs(&parts[0]);
 		boundary_to_degs(&parts[1]);
 		wkb = boundary_array_to_wkb(parts, 2);
-	}
-	else
-	{
-		boundary_to_degs(&boundary);
-		wkb = boundary_to_wkb(&boundary);
 	}
 
 	PG_RETURN_BYTEA_P(wkb);
@@ -86,12 +114,13 @@ boundary_to_degs(CellBoundary * boundary)
 	}
 }
 
-bool
-boundary_crosses_180(const CellBoundary * boundary)
+int
+boundary_crosses_180_num(const CellBoundary * boundary)
 {
 	const int	numVerts = boundary->numVerts;
 	const LatLng *verts = boundary->verts;
 
+    int num = 0;
 	for (int v = 0; v < numVerts; v++)
 	{
 		double		lon = verts[v].lng;
@@ -99,10 +128,10 @@ boundary_crosses_180(const CellBoundary * boundary)
 		if (SIGN(lon) != SIGN(nextLon)
 			&& fabs(lon - nextLon) > M_PI)
 		{
-			return true;
+			++num;
 		}
 	}
-	return false;
+	return num;
 }
 
 void
@@ -111,62 +140,90 @@ boundary_split_180(const CellBoundary * boundary, CellBoundary * part1, CellBoun
 	const int	numVerts = boundary->numVerts;
 	const LatLng *verts = boundary->verts;
 
-	CellBoundary *part,
-			   *prevPart;
-	LatLng		split;
-	int			prevSign = 0;
-	int			start = 0;		/* current batch start */
-
 	part1->numVerts = 0;
 	part2->numVerts = 0;
-	for (int v = 0; v <= numVerts; v++)
+	for (int v = 0; v < numVerts; v++)
 	{
-		int			cur = v % numVerts;
-		double		lon = verts[cur].lng;
-		int			sign = SIGN(lon);
+		int		next = (v + 1) % numVerts;
+		double		lon;
+		double		nextLon;
+		CellBoundary *part;
 
-		if (prevSign != 0 && sign != 0 && sign != prevSign)
+		lon = verts[v].lng;
+		nextLon = verts[next].lng;
+		part = (lon < 0) ? part1 : part2;
+
+		/* Add current vertex */
+		part->verts[part->numVerts++] = verts[v];
+
+		if (SIGN(lon) != SIGN(nextLon))
 		{
-			/* Crossing 0 or 180 meridian */
+			LatLng vert;
 
-			/*
-			 * Assuming boundary is crossed by 180 meridian at least once, so
-			 * segment has to be split by either anti or 0 meridian
-			 */
+			SPLIT_ASSERT(
+				fabs(lon - nextLon) > M_PI,
+				"Cell boundaries crossed by the Prime meridian "
+				"must be handled in `boundary_split_180_polar`");
 
-			int			prev = (v + numVerts - 1) % numVerts;
-			double		prevLon = verts[prev].lng;
-			bool		crossesZero = (fabs(lon - prevLon) < M_PI);
-
-			prevPart = (prevSign < 0) ? part1 : part2;
-			part = (sign < 0) ? part1 : part2;
-
-			/* Add points to prev. part */
-			for (int i = start; i < v && i < numVerts; i++)
-				prevPart->verts[prevPart->numVerts++] = verts[i];
-
-			/* Calc. split point latitude */
-			split.lat = split_180_lat(&verts[cur], &verts[prev]);
+			vert.lat = split_180_lat(&verts[v], &verts[next]);
+			vert.lng = (lon < 0) ? -M_PI : M_PI;
 
 			/* Add split point */
-			/* prev. part */
-			split.lng = crossesZero ? 0 : (prevLon < 0) ? -M_PI
-				: M_PI;
-			;
-			prevPart->verts[prevPart->numVerts++] = split;
-			/* current part */
-			split.lng = crossesZero ? 0 : -split.lng;
-			part->verts[part->numVerts++] = split;
-
-			start = v;			/* start next batch from current point */
+			/* current part  */
+			part->verts[part->numVerts++] = vert;
+			/* next part */
+			vert.lng = -vert.lng;
+			part = (part == part1) ? part2 : part1;
+			part->verts[part->numVerts++] = vert;
 		}
-
-		if (sign != 0)
-			prevSign = sign;
 	}
+}
 
-	/* Add remaining points */
-	part = (prevSign < 0) ? part1 : part2;
-	for (int i = start; i < numVerts; i++)
-		part->verts[part->numVerts++] = verts[i];
+void
+boundary_split_180_polar(const CellBoundary * boundary, CellBoundary * res)
+{
+	const int	numVerts = boundary->numVerts;
+	const LatLng *verts = boundary->verts;
+
+	res->numVerts = 0;
+	for (int v = 0; v < numVerts; v++)
+	{
+		int		next = (v + 1) % numVerts;
+		double		lon;
+		double		nextLon;
+
+		/* Add current vertex */
+		res->verts[res->numVerts++] = verts[v];
+
+		lon = verts[v].lng;
+		nextLon = verts[next].lng;
+		if (SIGN(lon) != SIGN(nextLon)
+			&& fabs(lon - nextLon) > M_PI)
+		{
+			LatLng vert;
+			double splitLat;
+
+			SPLIT_ASSERT(
+				v + 1 == res->numVerts,
+				"Cell boundaries crossed by antimeridian more than once "
+				"must be handled in `boundary_split_180`");
+
+			splitLat = split_180_lat(&verts[v], &verts[next]);
+
+			/* Add intersection point */
+			vert.lat = splitLat;
+			vert.lng = (lon < 0) ? -M_PI : M_PI;
+			res->verts[res->numVerts++] = vert;
+
+			/* Add points on antimeridian near the pole */
+			vert.lat = SIGN(vert.lat) * ABS_LAT_MAX;
+			res->verts[res->numVerts++] = vert;
+			vert.lng = -vert.lng;
+			res->verts[res->numVerts++] = vert;
+
+			/* Add intersection point */
+			vert.lat = splitLat;
+			res->verts[res->numVerts++] = vert;
+		}
+	}
 }

--- a/h3/test/expected/postgis.out
+++ b/h3/test/expected/postgis.out
@@ -5,6 +5,7 @@
 \set meter ST_SetSRID(ST_Point(6196902.235389061,1413172.0833316022), 3857)
 \set degree ST_SetSRID(ST_Point(55.6677199224442,12.592131261648213), 4326)
 \set edgecross '\'8003fffffffffff\'::h3index'
+\set polar '\'81f2bffffffffff\'::h3index'
 \set lat1 84.76455330449812
 \set lat2 89.980298101841
 \set epsilon 0.0000000000001
@@ -79,12 +80,20 @@ SELECT COUNT(*) = 48 FROM (
 SELECT h3_polygon_to_cells(h3_cell_to_boundary(:hexagon)::geometry::polygon, null, :resolution) = :hexagon;
  t
 
--- the boundary of of a non-edgecrossing index is a polygon
+-- the boundary of a non-edgecrossing index is a polygon
 SELECT GeometryType(h3_cell_to_boundary_wkb(:hexagon)::geometry) LIKE 'POLYGON';
  t
 
 -- the boundary of an edgecrossing index is a multipolygon when split
 SELECT GeometryType(h3_cell_to_boundary_wkb(:edgecross)::geometry) LIKE 'MULTIPOLYGON';
+ t
+
+-- the boundary of a polar cell is a polygon
+SELECT GeometryType(h3_cell_to_boundary_wkb(:polar)::geometry) LIKE 'POLYGON';
+ t
+
+-- check num points in polar cell boundary
+SELECT ST_NPoints(h3_cell_to_boundary_geometry(:polar)) = 11;
  t
 
 -- check latitude of antimeridian crossing points

--- a/h3/test/sql/postgis.sql
+++ b/h3/test/sql/postgis.sql
@@ -5,6 +5,7 @@
 \set meter ST_SetSRID(ST_Point(6196902.235389061,1413172.0833316022), 3857)
 \set degree ST_SetSRID(ST_Point(55.6677199224442,12.592131261648213), 4326)
 \set edgecross '\'8003fffffffffff\'::h3index'
+\set polar '\'81f2bffffffffff\'::h3index'
 \set lat1 84.76455330449812
 \set lat2 89.980298101841
 \set epsilon 0.0000000000001
@@ -73,11 +74,17 @@ SELECT COUNT(*) = 48 FROM (
 -- polyfill of geo boundary returns original index
 SELECT h3_polygon_to_cells(h3_cell_to_boundary(:hexagon)::geometry::polygon, null, :resolution) = :hexagon;
 
--- the boundary of of a non-edgecrossing index is a polygon
+-- the boundary of a non-edgecrossing index is a polygon
 SELECT GeometryType(h3_cell_to_boundary_wkb(:hexagon)::geometry) LIKE 'POLYGON';
 
 -- the boundary of an edgecrossing index is a multipolygon when split
 SELECT GeometryType(h3_cell_to_boundary_wkb(:edgecross)::geometry) LIKE 'MULTIPOLYGON';
+
+-- the boundary of a polar cell is a polygon
+SELECT GeometryType(h3_cell_to_boundary_wkb(:polar)::geometry) LIKE 'POLYGON';
+
+-- check num points in polar cell boundary
+SELECT ST_NPoints(h3_cell_to_boundary_geometry(:polar)) = 11;
 
 -- check latitude of antimeridian crossing points
 SET h3.split_antimeridian TO true;


### PR DESCRIPTION
Cutting polar cell boundaries by anti- and prime meridian creates a problem with presenting them in projections other than polar with new edges going from longitude +-180 to closer to 0.  Mercator (SRID=3857) projection of 0 resolution cells:
![poles](https://user-images.githubusercontent.com/1970037/200527578-0df36d01-0327-4618-a9fd-9ea7de2ad0da.png)

This fix adds a separate function for handling polar cell boundaries, "cutting" polygon along antimeridian from intersection point to (almost) the pole:
![pole-cut](https://user-images.githubusercontent.com/1970037/200531901-b4101991-0aa1-43a2-a1a9-001e905b88e2.png)

0 resolution cells with the fix:
![poles-fix](https://user-images.githubusercontent.com/1970037/200532001-a4aed580-2f4c-4a8b-86a8-787a029fbe73.png)
