### PR TITLE
Documentation generation: PostGIS reference, function references, ToC…

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ See [Advanced Install](#advanced-install) for other installation methods.
 
 Generally, all functions have been renamed from camelCase in H3 to snake\_case in SQL.
 
-See [API reference](docs/api.md) for all provided functions.
+See [API reference](https://pgxn.org/dist/h3/docs/api.html) for all provided functions.
 
 ## Building
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,66 +1,66 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+<!-- start table of contents -->
+**
+
 
 - [API Reference](#api-reference)
 - [Base type](#base-type)
 - [Indexing functions](#indexing-functions)
-    - [h3_lat_lng_to_cell(latlng `point`, resolution `integer`) ⇒ `h3index`](#h3_lat_lng_to_celllatlng-point-resolution-integer-%E2%87%92-h3index)
-    - [h3_cell_to_lat_lng(cell `h3index`) ⇒ `point`](#h3_cell_to_lat_lngcell-h3index-%E2%87%92-point)
-    - [h3_cell_to_boundary(cell `h3index`) ⇒ `polygon`](#h3_cell_to_boundarycell-h3index-%E2%87%92-polygon)
+  - [h3_lat_lng_to_cell(latlng `point`, resolution `integer`) ⇒ `h3index`](#h3_lat_lng_to_celllatlng-point-resolution-integer--h3index)
+  - [h3_cell_to_lat_lng(cell `h3index`) ⇒ `point`](#h3_cell_to_lat_lngcell-h3index--point)
+  - [h3_cell_to_boundary(cell `h3index`) ⇒ `polygon`](#h3_cell_to_boundarycell-h3index--polygon)
 - [Index inspection functions](#index-inspection-functions)
-    - [h3_get_resolution(`h3index`) ⇒ `integer`](#h3_get_resolutionh3index-%E2%87%92-integer)
-    - [h3_get_base_cell_number(`h3index`) ⇒ `integer`](#h3_get_base_cell_numberh3index-%E2%87%92-integer)
-    - [h3_is_valid_cell(`h3index`) ⇒ `boolean`](#h3_is_valid_cellh3index-%E2%87%92-boolean)
-    - [h3_is_res_class_iii(`h3index`) ⇒ `boolean`](#h3_is_res_class_iiih3index-%E2%87%92-boolean)
-    - [h3_is_pentagon(`h3index`) ⇒ `boolean`](#h3_is_pentagonh3index-%E2%87%92-boolean)
-    - [h3_get_icosahedron_faces(`h3index`) ⇒ `integer[]`](#h3_get_icosahedron_facesh3index-%E2%87%92-integer)
+  - [h3_get_resolution(`h3index`) ⇒ `integer`](#h3_get_resolutionh3index--integer)
+  - [h3_get_base_cell_number(`h3index`) ⇒ `integer`](#h3_get_base_cell_numberh3index--integer)
+  - [h3_is_valid_cell(`h3index`) ⇒ `boolean`](#h3_is_valid_cellh3index--boolean)
+  - [h3_is_res_class_iii(`h3index`) ⇒ `boolean`](#h3_is_res_class_iiih3index--boolean)
+  - [h3_is_pentagon(`h3index`) ⇒ `boolean`](#h3_is_pentagonh3index--boolean)
+  - [h3_get_icosahedron_faces(`h3index`) ⇒ `integer[]`](#h3_get_icosahedron_facesh3index--integer)
 - [Grid traversal functions](#grid-traversal-functions)
-    - [h3_grid_disk(origin `h3index`, [k `integer` = 1]) ⇒ SETOF `h3index`](#h3_grid_diskorigin-h3index-k-integer--1-%E2%87%92-setof-h3index)
-    - [h3_grid_disk_distances(origin `h3index`, [k `integer` = 1], OUT index `h3index`, OUT distance `int`) ⇒ SETOF `record`](#h3_grid_disk_distancesorigin-h3index-k-integer--1-out-index-h3index-out-distance-int-%E2%87%92-setof-record)
-    - [h3_grid_ring_unsafe(origin `h3index`, [k `integer` = 1]) ⇒ SETOF `h3index`](#h3_grid_ring_unsafeorigin-h3index-k-integer--1-%E2%87%92-setof-h3index)
-    - [h3_grid_path_cells(origin `h3index`, destination `h3index`) ⇒ SETOF `h3index`](#h3_grid_path_cellsorigin-h3index-destination-h3index-%E2%87%92-setof-h3index)
-    - [h3_grid_distance(origin `h3index`, destination `h3index`) ⇒ `bigint`](#h3_grid_distanceorigin-h3index-destination-h3index-%E2%87%92-bigint)
-    - [h3_cell_to_local_ij(origin `h3index`, index `h3index`) ⇒ `point`](#h3_cell_to_local_ijorigin-h3index-index-h3index-%E2%87%92-point)
-    - [h3_local_ij_to_cell(origin `h3index`, coord `point`) ⇒ `h3index`](#h3_local_ij_to_cellorigin-h3index-coord-point-%E2%87%92-h3index)
+  - [h3_grid_disk(origin `h3index`, [k `integer` = 1]) ⇒ SETOF `h3index`](#h3_grid_diskorigin-h3index-k-integer--1--setof-h3index)
+  - [h3_grid_disk_distances(origin `h3index`, [k `integer` = 1], OUT index `h3index`, OUT distance `int`) ⇒ SETOF `record`](#h3_grid_disk_distancesorigin-h3index-k-integer--1-out-index-h3index-out-distance-int--setof-record)
+  - [h3_grid_ring_unsafe(origin `h3index`, [k `integer` = 1]) ⇒ SETOF `h3index`](#h3_grid_ring_unsafeorigin-h3index-k-integer--1--setof-h3index)
+  - [h3_grid_path_cells(origin `h3index`, destination `h3index`) ⇒ SETOF `h3index`](#h3_grid_path_cellsorigin-h3index-destination-h3index--setof-h3index)
+  - [h3_grid_distance(origin `h3index`, destination `h3index`) ⇒ `bigint`](#h3_grid_distanceorigin-h3index-destination-h3index--bigint)
+  - [h3_cell_to_local_ij(origin `h3index`, index `h3index`) ⇒ `point`](#h3_cell_to_local_ijorigin-h3index-index-h3index--point)
+  - [h3_local_ij_to_cell(origin `h3index`, coord `point`) ⇒ `h3index`](#h3_local_ij_to_cellorigin-h3index-coord-point--h3index)
 - [Hierarchical grid functions](#hierarchical-grid-functions)
-    - [h3_cell_to_parent(cell `h3index`, resolution `integer`) ⇒ `h3index`](#h3_cell_to_parentcell-h3index-resolution-integer-%E2%87%92-h3index)
-    - [h3_cell_to_children(cell `h3index`, resolution `integer`) ⇒ SETOF `h3index`](#h3_cell_to_childrencell-h3index-resolution-integer-%E2%87%92-setof-h3index)
-    - [h3_cell_to_center_child(cell `h3index`, resolution `integer`) ⇒ `h3index`](#h3_cell_to_center_childcell-h3index-resolution-integer-%E2%87%92-h3index)
-    - [h3_compact_cells(cells `h3index[]`) ⇒ SETOF `h3index`](#h3_compact_cellscells-h3index-%E2%87%92-setof-h3index)
-    - [h3_uncompact_cells(cells `h3index[]`, resolution `integer`) ⇒ SETOF `h3index`](#h3_uncompact_cellscells-h3index-resolution-integer-%E2%87%92-setof-h3index)
-    - [h3_cell_to_parent(cell `h3index`) ⇒ `h3index`](#h3_cell_to_parentcell-h3index-%E2%87%92-h3index)
-    - [h3_cell_to_children(cell `h3index`) ⇒ SETOF `h3index`](#h3_cell_to_childrencell-h3index-%E2%87%92-setof-h3index)
-    - [h3_cell_to_center_child(cell `h3index`) ⇒ `h3index`](#h3_cell_to_center_childcell-h3index-%E2%87%92-h3index)
-    - [h3_uncompact_cells(cells `h3index[]`) ⇒ SETOF `h3index`](#h3_uncompact_cellscells-h3index-%E2%87%92-setof-h3index)
-    - [h3_cell_to_children_slow(index `h3index`, resolution `integer`) ⇒ SETOF `h3index`](#h3_cell_to_children_slowindex-h3index-resolution-integer-%E2%87%92-setof-h3index)
-    - [h3_cell_to_children_slow(index `h3index`) ⇒ SETOF `h3index`](#h3_cell_to_children_slowindex-h3index-%E2%87%92-setof-h3index)
+  - [h3_cell_to_parent(cell `h3index`, resolution `integer`) ⇒ `h3index`](#h3_cell_to_parentcell-h3index-resolution-integer--h3index)
+  - [h3_cell_to_children(cell `h3index`, resolution `integer`) ⇒ SETOF `h3index`](#h3_cell_to_childrencell-h3index-resolution-integer--setof-h3index)
+  - [h3_cell_to_center_child(cell `h3index`, resolution `integer`) ⇒ `h3index`](#h3_cell_to_center_childcell-h3index-resolution-integer--h3index)
+  - [h3_compact_cells(cells `h3index[]`) ⇒ SETOF `h3index`](#h3_compact_cellscells-h3index--setof-h3index)
+  - [h3_uncompact_cells(cells `h3index[]`, resolution `integer`) ⇒ SETOF `h3index`](#h3_uncompact_cellscells-h3index-resolution-integer--setof-h3index)
+  - [h3_cell_to_parent(cell `h3index`) ⇒ `h3index`](#h3_cell_to_parentcell-h3index--h3index)
+  - [h3_cell_to_children(cell `h3index`) ⇒ SETOF `h3index`](#h3_cell_to_childrencell-h3index--setof-h3index)
+  - [h3_cell_to_center_child(cell `h3index`) ⇒ `h3index`](#h3_cell_to_center_childcell-h3index--h3index)
+  - [h3_uncompact_cells(cells `h3index[]`) ⇒ SETOF `h3index`](#h3_uncompact_cellscells-h3index--setof-h3index)
+  - [h3_cell_to_children_slow(index `h3index`, resolution `integer`) ⇒ SETOF `h3index`](#h3_cell_to_children_slowindex-h3index-resolution-integer--setof-h3index)
+  - [h3_cell_to_children_slow(index `h3index`) ⇒ SETOF `h3index`](#h3_cell_to_children_slowindex-h3index--setof-h3index)
 - [Region functions](#region-functions)
-    - [h3_polygon_to_cells(exterior `polygon`, holes `polygon[]`, [resolution `integer` = 1]) ⇒ SETOF `h3index`](#h3_polygon_to_cellsexterior-polygon-holes-polygon-resolution-integer--1-%E2%87%92-setof-h3index)
-    - [h3_cells_to_multi_polygon(`h3index[]`, OUT exterior `polygon`, OUT holes `polygon[]`) ⇒ SETOF `record`](#h3_cells_to_multi_polygonh3index-out-exterior-polygon-out-holes-polygon-%E2%87%92-setof-record)
+  - [h3_polygon_to_cells(exterior `polygon`, holes `polygon[]`, [resolution `integer` = 1]) ⇒ SETOF `h3index`](#h3_polygon_to_cellsexterior-polygon-holes-polygon-resolution-integer--1--setof-h3index)
+  - [h3_cells_to_multi_polygon(`h3index[]`, OUT exterior `polygon`, OUT holes `polygon[]`) ⇒ SETOF `record`](#h3_cells_to_multi_polygonh3index-out-exterior-polygon-out-holes-polygon--setof-record)
 - [Unidirectional edge functions](#unidirectional-edge-functions)
-    - [h3_are_neighbor_cells(origin `h3index`, destination `h3index`) ⇒ `boolean`](#h3_are_neighbor_cellsorigin-h3index-destination-h3index-%E2%87%92-boolean)
-    - [h3_cells_to_directed_edge(origin `h3index`, destination `h3index`) ⇒ `h3index`](#h3_cells_to_directed_edgeorigin-h3index-destination-h3index-%E2%87%92-h3index)
-    - [h3_is_valid_directed_edge(edge `h3index`) ⇒ `boolean`](#h3_is_valid_directed_edgeedge-h3index-%E2%87%92-boolean)
-    - [h3_get_directed_edge_origin(edge `h3index`) ⇒ `h3index`](#h3_get_directed_edge_originedge-h3index-%E2%87%92-h3index)
-    - [h3_get_directed_edge_destination(edge `h3index`) ⇒ `h3index`](#h3_get_directed_edge_destinationedge-h3index-%E2%87%92-h3index)
-    - [h3_directed_edge_to_cells(edge `h3index`, OUT origin `h3index`, OUT destination `h3index`) ⇒ `record`](#h3_directed_edge_to_cellsedge-h3index-out-origin-h3index-out-destination-h3index-%E2%87%92-record)
-    - [h3_origin_to_directed_edges(`h3index`) ⇒ SETOF `h3index`](#h3_origin_to_directed_edgesh3index-%E2%87%92-setof-h3index)
-    - [h3_directed_edge_to_boundary(edge `h3index`) ⇒ `polygon`](#h3_directed_edge_to_boundaryedge-h3index-%E2%87%92-polygon)
+  - [h3_are_neighbor_cells(origin `h3index`, destination `h3index`) ⇒ `boolean`](#h3_are_neighbor_cellsorigin-h3index-destination-h3index--boolean)
+  - [h3_cells_to_directed_edge(origin `h3index`, destination `h3index`) ⇒ `h3index`](#h3_cells_to_directed_edgeorigin-h3index-destination-h3index--h3index)
+  - [h3_is_valid_directed_edge(edge `h3index`) ⇒ `boolean`](#h3_is_valid_directed_edgeedge-h3index--boolean)
+  - [h3_get_directed_edge_origin(edge `h3index`) ⇒ `h3index`](#h3_get_directed_edge_originedge-h3index--h3index)
+  - [h3_get_directed_edge_destination(edge `h3index`) ⇒ `h3index`](#h3_get_directed_edge_destinationedge-h3index--h3index)
+  - [h3_directed_edge_to_cells(edge `h3index`, OUT origin `h3index`, OUT destination `h3index`) ⇒ `record`](#h3_directed_edge_to_cellsedge-h3index-out-origin-h3index-out-destination-h3index--record)
+  - [h3_origin_to_directed_edges(`h3index`) ⇒ SETOF `h3index`](#h3_origin_to_directed_edgesh3index--setof-h3index)
+  - [h3_directed_edge_to_boundary(edge `h3index`) ⇒ `polygon`](#h3_directed_edge_to_boundaryedge-h3index--polygon)
 - [H3 Vertex functions](#h3-vertex-functions)
-    - [h3_cell_to_vertex(cell `h3index`, vertexNum `integer`) ⇒ `h3index`](#h3_cell_to_vertexcell-h3index-vertexnum-integer-%E2%87%92-h3index)
-    - [h3_cell_to_vertexes(cell `h3index`) ⇒ SETOF `h3index`](#h3_cell_to_vertexescell-h3index-%E2%87%92-setof-h3index)
-    - [h3_vertex_to_lat_lng(vertex `h3index`) ⇒ `point`](#h3_vertex_to_lat_lngvertex-h3index-%E2%87%92-point)
-    - [h3_is_valid_vertex(vertex `h3index`) ⇒ `boolean`](#h3_is_valid_vertexvertex-h3index-%E2%87%92-boolean)
+  - [h3_cell_to_vertex(cell `h3index`, vertexNum `integer`) ⇒ `h3index`](#h3_cell_to_vertexcell-h3index-vertexnum-integer--h3index)
+  - [h3_cell_to_vertexes(cell `h3index`) ⇒ SETOF `h3index`](#h3_cell_to_vertexescell-h3index--setof-h3index)
+  - [h3_vertex_to_lat_lng(vertex `h3index`) ⇒ `point`](#h3_vertex_to_lat_lngvertex-h3index--point)
+  - [h3_is_valid_vertex(vertex `h3index`) ⇒ `boolean`](#h3_is_valid_vertexvertex-h3index--boolean)
 - [Miscellaneous H3 functions](#miscellaneous-h3-functions)
-    - [h3_great_circle_distance(a `point`, b `point`, [unit `text` = km]) ⇒ `double precision`](#h3_great_circle_distancea-point-b-point-unit-text--km-%E2%87%92-double-precision)
-    - [h3_get_hexagon_area_avg(resolution `integer`, [unit `text` = km]) ⇒ `double precision`](#h3_get_hexagon_area_avgresolution-integer-unit-text--km-%E2%87%92-double-precision)
-    - [h3_cell_area(cell `h3index`, [unit `text` = km^2]) ⇒ `double precision`](#h3_cell_areacell-h3index-unit-text--km%5E2-%E2%87%92-double-precision)
-    - [h3_get_hexagon_edge_length_avg(resolution `integer`, [unit `text` = km]) ⇒ `double precision`](#h3_get_hexagon_edge_length_avgresolution-integer-unit-text--km-%E2%87%92-double-precision)
-    - [h3_edge_length(edge `h3index`, [unit `text` = km]) ⇒ `double precision`](#h3_edge_lengthedge-h3index-unit-text--km-%E2%87%92-double-precision)
-    - [h3_get_num_cells(resolution `integer`) ⇒ `bigint`](#h3_get_num_cellsresolution-integer-%E2%87%92-bigint)
-    - [h3_get_res_0_cells() ⇒ SETOF `h3index`](#h3_get_res_0_cells-%E2%87%92-setof-h3index)
-    - [h3_get_pentagons(resolution `integer`) ⇒ SETOF `h3index`](#h3_get_pentagonsresolution-integer-%E2%87%92-setof-h3index)
+  - [h3_great_circle_distance(a `point`, b `point`, [unit `text` = km]) ⇒ `double precision`](#h3_great_circle_distancea-point-b-point-unit-text--km--double-precision)
+  - [h3_get_hexagon_area_avg(resolution `integer`, [unit `text` = km]) ⇒ `double precision`](#h3_get_hexagon_area_avgresolution-integer-unit-text--km--double-precision)
+  - [h3_cell_area(cell `h3index`, [unit `text` = km^2]) ⇒ `double precision`](#h3_cell_areacell-h3index-unit-text--km2--double-precision)
+  - [h3_get_hexagon_edge_length_avg(resolution `integer`, [unit `text` = km]) ⇒ `double precision`](#h3_get_hexagon_edge_length_avgresolution-integer-unit-text--km--double-precision)
+  - [h3_edge_length(edge `h3index`, [unit `text` = km]) ⇒ `double precision`](#h3_edge_lengthedge-h3index-unit-text--km--double-precision)
+  - [h3_get_num_cells(resolution `integer`) ⇒ `bigint`](#h3_get_num_cellsresolution-integer--bigint)
+  - [h3_get_res_0_cells() ⇒ SETOF `h3index`](#h3_get_res_0_cells--setof-h3index)
+  - [h3_get_pentagons(resolution `integer`) ⇒ SETOF `h3index`](#h3_get_pentagonsresolution-integer--setof-h3index)
 - [Operators](#operators)
   - [B-tree operators](#b-tree-operators)
     - [Operator: `h3index` = `h3index`](#operator-h3index--h3index)
@@ -71,24 +71,44 @@
     - [Operator: `h3index` <@ `h3index`](#operator-h3index--h3index)
     - [Operator: `h3index` <-> `h3index`](#operator-h3index---h3index)
 - [Type casts](#type-casts)
-    - [`h3index` :: `bigint`](#h3index--bigint)
-    - [`bigint` :: `h3index`](#bigint--h3index)
-    - [`h3index` :: `point`](#h3index--point)
+  - [`h3index` :: `bigint`](#h3index--bigint)
+  - [`bigint` :: `h3index`](#bigint--h3index)
+  - [`h3index` :: `point`](#h3index--point)
 - [Extension specific functions](#extension-specific-functions)
-    - [h3_get_extension_version() ⇒ `text`](#h3_get_extension_version-%E2%87%92-text)
+  - [h3_get_extension_version() ⇒ `text`](#h3_get_extension_version--text)
 - [WKB indexing functions](#wkb-indexing-functions)
-    - [h3_cell_to_boundary_wkb(cell `h3index`) ⇒ `bytea`](#h3_cell_to_boundary_wkbcell-h3index-%E2%87%92-bytea)
+  - [h3_cell_to_boundary_wkb(cell `h3index`) ⇒ `bytea`](#h3_cell_to_boundary_wkbcell-h3index--bytea)
 - [WKB regions functions](#wkb-regions-functions)
-    - [h3_cells_to_multi_polygon_wkb(`h3index[]`) ⇒ `bytea`](#h3_cells_to_multi_polygon_wkbh3index-%E2%87%92-bytea)
+  - [h3_cells_to_multi_polygon_wkb(`h3index[]`) ⇒ `bytea`](#h3_cells_to_multi_polygon_wkbh3index--bytea)
 - [Deprecated functions](#deprecated-functions)
-    - [h3_cell_to_boundary(cell `h3index`, extend_antimeridian `boolean`) ⇒ `polygon`](#h3_cell_to_boundarycell-h3index-extend_antimeridian-boolean-%E2%87%92-polygon)
+  - [h3_cell_to_boundary(cell `h3index`, extend_antimeridian `boolean`) ⇒ `polygon`](#h3_cell_to_boundarycell-h3index-extend_antimeridian-boolean--polygon)
+- [PostGIS Integration](#postgis-integration)
+- [PostGIS Indexing Functions](#postgis-indexing-functions)
+  - [h3_lat_lng_to_cell(`geometry`, resolution `integer`) ⇒ `h3index`](#h3_lat_lng_to_cellgeometry-resolution-integer--h3index)
+  - [h3_lat_lng_to_cell(`geography`, resolution `integer`) ⇒ `h3index`](#h3_lat_lng_to_cellgeography-resolution-integer--h3index)
+  - [h3_cell_to_geometry(`h3index`) ⇒ `geometry`](#h3_cell_to_geometryh3index--geometry)
+  - [h3_cell_to_geography(`h3index`) ⇒ `geography`](#h3_cell_to_geographyh3index--geography)
+  - [h3_cell_to_boundary_geometry(`h3index`) ⇒ `geometry`](#h3_cell_to_boundary_geometryh3index--geometry)
+  - [h3_cell_to_boundary_geography(`h3index`) ⇒ `geography`](#h3_cell_to_boundary_geographyh3index--geography)
+- [PostGIS Grid Traversal Functions](#postgis-grid-traversal-functions)
+  - [h3_grid_path_cells_recursive(origin `h3index`, destination `h3index`) ⇒ SETOF `h3index`](#h3_grid_path_cells_recursiveorigin-h3index-destination-h3index--setof-h3index)
+- [PostGIS Region Functions](#postgis-region-functions)
+  - [h3_polygon_to_cells(multi `geometry`, resolution `integer`) ⇒ SETOF `h3index`](#h3_polygon_to_cellsmulti-geometry-resolution-integer--setof-h3index)
+  - [h3_polygon_to_cells(multi `geography`, resolution `integer`) ⇒ SETOF `h3index`](#h3_polygon_to_cellsmulti-geography-resolution-integer--setof-h3index)
+  - [h3_cells_to_multi_polygon_geometry(`h3index[]`) ⇒ `geometry`](#h3_cells_to_multi_polygon_geometryh3index--geometry)
+  - [h3_cells_to_multi_polygon_geography(`h3index[]`) ⇒ `geography`](#h3_cells_to_multi_polygon_geographyh3index--geography)
+  - [h3_cells_to_multi_polygon_geometry(setof `h3index`)](#h3_cells_to_multi_polygon_geometrysetof-h3index)
+  - [h3_cells_to_multi_polygon_geography(setof `h3index`)](#h3_cells_to_multi_polygon_geographysetof-h3index)
+- [PostGIS casts](#postgis-casts)
+  - [`h3index` :: `geometry`](#h3index--geometry)
+  - [`h3index` :: `geography`](#h3index--geography)
 
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- end table of contents -->
+
 
 # API Reference
 
 # Base type
-
 An unsigned 64-bit integer representing any H3 object (hexagon, pentagon, directed edge ...)
 represented as a (or 16-character) hexadecimal string, like '8928308280fffff'.
 
@@ -99,36 +119,39 @@ represented as a (or 16-character) hexadecimal string, like '8928308280fffff'.
 
 
 # Indexing functions
-
 These function are used for finding the H3 index containing coordinates,
 and for finding the center and boundary of H3 indexes.
 
 ### h3_lat_lng_to_cell(latlng `point`, resolution `integer`) ⇒ `h3index`
 *Since v4.0.0*
 
+See also: <a href="#h3_lat_lng_to_cellgeometry-resolution-integer--h3index">h3_lat_lng_to_cell(`geometry`, `integer`)</a>, <a href="#h3_lat_lng_to_cellgeography-resolution-integer--h3index">h3_lat_lng_to_cell(`geography`, `integer`)</a>
+
 
 Indexes the location at the specified resolution.
-
 
 
 ### h3_cell_to_lat_lng(cell `h3index`) ⇒ `point`
 *Since v4.0.0*
 
+See also: <a href="#h3_cell_to_geometryh3index--geometry">h3_cell_to_geometry(`h3index`)</a>, <a href="#h3_cell_to_geographyh3index--geography">h3_cell_to_geography(`h3index`)</a>
+
 
 Finds the centroid of the index.
 
 
-
 ### h3_cell_to_boundary(cell `h3index`) ⇒ `polygon`
 *Since v4.0.0*
+
+See also: <a href="#h3_cell_to_boundary_geometryh3index--geometry">h3_cell_to_boundary_geometry(`h3index`)</a>, <a href="#h3_cell_to_boundary_geographyh3index--geography">h3_cell_to_boundary_geography(`h3index`)</a>
 
 
 Finds the boundary of the index.
 
 Use `SET h3.extend_antimeridian TO true` to extend coordinates when crossing 180th meridian.
 
-# Index inspection functions
 
+# Index inspection functions
 These functions provide metadata about an H3 index, such as its resolution
 or base cell, and provide utilities for converting into and out of the
 64-bit representation of an H3 index.
@@ -140,13 +163,11 @@ or base cell, and provide utilities for converting into and out of the
 Returns the resolution of the index.
 
 
-
 ### h3_get_base_cell_number(`h3index`) ⇒ `integer`
 *Since v4.0.0*
 
 
 Returns the base cell number of the index.
-
 
 
 ### h3_is_valid_cell(`h3index`) ⇒ `boolean`
@@ -156,13 +177,11 @@ Returns the base cell number of the index.
 Returns true if the given H3Index is valid.
 
 
-
 ### h3_is_res_class_iii(`h3index`) ⇒ `boolean`
 *Since v1.0.0*
 
 
 Returns true if this index has a resolution with Class III orientation.
-
 
 
 ### h3_is_pentagon(`h3index`) ⇒ `boolean`
@@ -172,15 +191,14 @@ Returns true if this index has a resolution with Class III orientation.
 Returns true if this index represents a pentagonal cell.
 
 
-
 ### h3_get_icosahedron_faces(`h3index`) ⇒ `integer[]`
 *Since v4.0.0*
 
 
 Find all icosahedron faces intersected by a given H3 index.
 
-# Grid traversal functions
 
+# Grid traversal functions
 Grid traversal allows finding cells in the vicinity of an origin cell, and
 determining how to traverse the grid from one cell to another.
 
@@ -191,7 +209,6 @@ determining how to traverse the grid from one cell to another.
 Produces indices within "k" distance of the origin index.
 
 
-
 ### h3_grid_disk_distances(origin `h3index`, [k `integer` = 1], OUT index `h3index`, OUT distance `int`) ⇒ SETOF `record`
 *Since v4.0.0*
 
@@ -199,13 +216,11 @@ Produces indices within "k" distance of the origin index.
 Produces indices within "k" distance of the origin index paired with their distance to the origin.
 
 
-
 ### h3_grid_ring_unsafe(origin `h3index`, [k `integer` = 1]) ⇒ SETOF `h3index`
 *Since v4.0.0*
 
 
 Returns the hollow hexagonal ring centered at origin with distance "k".
-
 
 
 ### h3_grid_path_cells(origin `h3index`, destination `h3index`) ⇒ SETOF `h3index`
@@ -219,13 +234,11 @@ example if they are very far apart. It may also fail when finding
 distances for indexes on opposite sides of a pentagon.
 
 
-
 ### h3_grid_distance(origin `h3index`, destination `h3index`) ⇒ `bigint`
 *Since v4.0.0*
 
 
 Returns the distance in grid cells between the two indices.
-
 
 
 ### h3_cell_to_local_ij(origin `h3index`, index `h3index`) ⇒ `point`
@@ -235,15 +248,14 @@ Returns the distance in grid cells between the two indices.
 Produces local IJ coordinates for an H3 index anchored by an origin.
 
 
-
 ### h3_local_ij_to_cell(origin `h3index`, coord `point`) ⇒ `h3index`
 *Since v0.2.0*
 
 
 Produces an H3 index from local IJ coordinates anchored by an origin.
 
-# Hierarchical grid functions
 
+# Hierarchical grid functions
 These functions permit moving between resolutions in the H3 grid system.
 The functions produce parent (coarser) or children (finer) cells.
 
@@ -254,13 +266,11 @@ The functions produce parent (coarser) or children (finer) cells.
 Returns the parent of the given index.
 
 
-
 ### h3_cell_to_children(cell `h3index`, resolution `integer`) ⇒ SETOF `h3index`
 *Since v4.0.0*
 
 
 Returns the set of children of the given index.
-
 
 
 ### h3_cell_to_center_child(cell `h3index`, resolution `integer`) ⇒ `h3index`
@@ -270,13 +280,11 @@ Returns the set of children of the given index.
 Returns the center child (finer) index contained by input index at given resolution.
 
 
-
 ### h3_compact_cells(cells `h3index[]`) ⇒ SETOF `h3index`
 *Since v4.0.0*
 
 
 Compacts the given array as best as possible.
-
 
 
 ### h3_uncompact_cells(cells `h3index[]`, resolution `integer`) ⇒ SETOF `h3index`
@@ -286,13 +294,11 @@ Compacts the given array as best as possible.
 Uncompacts the given array at the given resolution.
 
 
-
 ### h3_cell_to_parent(cell `h3index`) ⇒ `h3index`
 *Since v4.0.0*
 
 
 Returns the parent of the given index.
-
 
 
 ### h3_cell_to_children(cell `h3index`) ⇒ SETOF `h3index`
@@ -302,13 +308,11 @@ Returns the parent of the given index.
 Returns the set of children of the given index.
 
 
-
 ### h3_cell_to_center_child(cell `h3index`) ⇒ `h3index`
 *Since v4.0.0*
 
 
 Returns the center child (finer) index contained by input index at next resolution.
-
 
 
 ### h3_uncompact_cells(cells `h3index[]`) ⇒ SETOF `h3index`
@@ -318,8 +322,6 @@ Returns the center child (finer) index contained by input index at next resoluti
 Uncompacts the given array at the resolution one higher than the highest resolution in the set.
 
 
-
-
 ### h3_cell_to_children_slow(index `h3index`, resolution `integer`) ⇒ SETOF `h3index`
 *Since v4.0.0*
 
@@ -327,14 +329,13 @@ Uncompacts the given array at the resolution one higher than the highest resolut
 Slower version of H3ToChildren but allocates less memory.
 
 
-
 ### h3_cell_to_children_slow(index `h3index`) ⇒ SETOF `h3index`
 
 
 Slower version of H3ToChildren but allocates less memory.
 
-# Region functions
 
+# Region functions
 These functions convert H3 indexes to and from polygonal areas.
 
 ### h3_polygon_to_cells(exterior `polygon`, holes `polygon[]`, [resolution `integer` = 1]) ⇒ SETOF `h3index`
@@ -344,15 +345,14 @@ These functions convert H3 indexes to and from polygonal areas.
 Takes an exterior polygon [and a set of hole polygon] and returns the set of hexagons that best fit the structure.
 
 
-
 ### h3_cells_to_multi_polygon(`h3index[]`, OUT exterior `polygon`, OUT holes `polygon[]`) ⇒ SETOF `record`
 *Since v4.0.0*
 
 
 Create a LinkedGeoPolygon describing the outline(s) of a set of hexagons. Polygon outlines will follow GeoJSON MultiPolygon order: Each polygon will have one outer loop, which is first in the list, followed by any holes.
 
-# Unidirectional edge functions
 
+# Unidirectional edge functions
 Unidirectional edges allow encoding the directed edge from one cell to a
 neighboring cell.
 
@@ -363,13 +363,11 @@ neighboring cell.
 Returns true if the given indices are neighbors.
 
 
-
 ### h3_cells_to_directed_edge(origin `h3index`, destination `h3index`) ⇒ `h3index`
 *Since v4.0.0*
 
 
 Returns a unidirectional edge H3 index based on the provided origin and destination.
-
 
 
 ### h3_is_valid_directed_edge(edge `h3index`) ⇒ `boolean`
@@ -379,13 +377,11 @@ Returns a unidirectional edge H3 index based on the provided origin and destinat
 Returns true if the given edge is valid.
 
 
-
 ### h3_get_directed_edge_origin(edge `h3index`) ⇒ `h3index`
 *Since v4.0.0*
 
 
 Returns the origin index from the given edge.
-
 
 
 ### h3_get_directed_edge_destination(edge `h3index`) ⇒ `h3index`
@@ -395,13 +391,11 @@ Returns the origin index from the given edge.
 Returns the destination index from the given edge.
 
 
-
 ### h3_directed_edge_to_cells(edge `h3index`, OUT origin `h3index`, OUT destination `h3index`) ⇒ `record`
 *Since v4.0.0*
 
 
 Returns the pair of indices from the given edge.
-
 
 
 ### h3_origin_to_directed_edges(`h3index`) ⇒ SETOF `h3index`
@@ -411,15 +405,14 @@ Returns the pair of indices from the given edge.
 Returns all unidirectional edges with the given index as origin.
 
 
-
 ### h3_directed_edge_to_boundary(edge `h3index`) ⇒ `polygon`
 *Since v4.0.0*
 
 
 Provides the coordinates defining the unidirectional edge.
 
-# H3 Vertex functions
 
+# H3 Vertex functions
 Functions for working with cell vertexes.
 
 ### h3_cell_to_vertex(cell `h3index`, vertexNum `integer`) ⇒ `h3index`
@@ -429,13 +422,11 @@ Functions for working with cell vertexes.
 Returns a single vertex for a given cell, as an H3 index.
 
 
-
 ### h3_cell_to_vertexes(cell `h3index`) ⇒ SETOF `h3index`
 *Since v4.0.0*
 
 
 Returns all vertexes for a given cell, as H3 indexes.
-
 
 
 ### h3_vertex_to_lat_lng(vertex `h3index`) ⇒ `point`
@@ -445,15 +436,14 @@ Returns all vertexes for a given cell, as H3 indexes.
 Get the geocoordinates of an H3 vertex.
 
 
-
 ### h3_is_valid_vertex(vertex `h3index`) ⇒ `boolean`
 *Since v4.0.0*
 
 
 Whether the input is a valid H3 vertex.
 
-# Miscellaneous H3 functions
 
+# Miscellaneous H3 functions
 These functions include descriptions of the H3 grid system.
 
 ### h3_great_circle_distance(a `point`, b `point`, [unit `text` = km]) ⇒ `double precision`
@@ -463,13 +453,11 @@ These functions include descriptions of the H3 grid system.
 The great circle distance in radians between two spherical coordinates.
 
 
-
 ### h3_get_hexagon_area_avg(resolution `integer`, [unit `text` = km]) ⇒ `double precision`
 *Since v4.0.0*
 
 
 Average hexagon area in square (kilo)meters at the given resolution.
-
 
 
 ### h3_cell_area(cell `h3index`, [unit `text` = km^2]) ⇒ `double precision`
@@ -479,13 +467,11 @@ Average hexagon area in square (kilo)meters at the given resolution.
 Exact area for a specific cell (hexagon or pentagon).
 
 
-
 ### h3_get_hexagon_edge_length_avg(resolution `integer`, [unit `text` = km]) ⇒ `double precision`
 *Since v4.0.0*
 
 
 Average hexagon edge length in (kilo)meters at the given resolution.
-
 
 
 ### h3_edge_length(edge `h3index`, [unit `text` = km]) ⇒ `double precision`
@@ -495,13 +481,11 @@ Average hexagon edge length in (kilo)meters at the given resolution.
 Exact length for a specific unidirectional edge.
 
 
-
 ### h3_get_num_cells(resolution `integer`) ⇒ `bigint`
 *Since v4.0.0*
 
 
 Number of unique H3 indexes at the given resolution.
-
 
 
 ### h3_get_res_0_cells() ⇒ SETOF `h3index`
@@ -511,14 +495,15 @@ Number of unique H3 indexes at the given resolution.
 Returns all 122 resolution 0 indexes.
 
 
-
 ### h3_get_pentagons(resolution `integer`) ⇒ SETOF `h3index`
 *Since v4.0.0*
 
 
 All the pentagon H3 indexes at the specified resolution.
 
+
 # Operators
+
 ## B-tree operators
 
 ### Operator: `h3index` = `h3index`
@@ -528,17 +513,8 @@ All the pentagon H3 indexes at the specified resolution.
 Returns true if two indexes are the same.
 
 
-
 ### Operator: `h3index` <> `h3index`
 *Since v0.1.0*
-
-
-
-
-
-
-
-
 
 
 ## R-tree Operators
@@ -550,13 +526,11 @@ Returns true if two indexes are the same.
 Returns true if the two H3 indexes intersect.
 
 
-
 ### Operator: `h3index` @> `h3index`
 *Since v3.6.1*
 
 
 Returns true if A containts B.
-
 
 
 ### Operator: `h3index` <@ `h3index`
@@ -573,16 +547,12 @@ Returns true if A is contained by B.
 Returns the distance in grid cells between the two indices.
 
 
-
-
-
 # Type casts
 
 ### `h3index` :: `bigint`
 
 
 Convert H3 index to bigint, which is useful when you need a decimal representation.
-
 
 
 ### `bigint` :: `h3index`
@@ -596,6 +566,7 @@ Convert bigint to H3 index.
 
 Convert H3 index to point.
 
+
 # Extension specific functions
 
 ### h3_get_extension_version() ⇒ `text`
@@ -603,6 +574,7 @@ Convert H3 index to point.
 
 
 Get the currently installed version of the extension.
+
 
 # WKB indexing functions
 
@@ -627,11 +599,103 @@ Create a LinkedGeoPolygon describing the outline(s) of a set of hexagons, conver
 
 Splits polygons when crossing 180th meridian.
 
+
 # Deprecated functions
 
 ### h3_cell_to_boundary(cell `h3index`, extend_antimeridian `boolean`) ⇒ `polygon`
 
 
 DEPRECATED: Use `SET h3.extend_antimeridian TO true` instead.
+
+# PostGIS Integration
+
+# PostGIS Indexing Functions
+
+### h3_lat_lng_to_cell(`geometry`, resolution `integer`) ⇒ `h3index`
+*Since v4.0.0*
+
+
+Indexes the location at the specified resolution.
+
+
+### h3_lat_lng_to_cell(`geography`, resolution `integer`) ⇒ `h3index`
+*Since v4.0.0*
+
+
+Indexes the location at the specified resolution.
+
+
+### h3_cell_to_geometry(`h3index`) ⇒ `geometry`
+*Since v4.0.0*
+
+
+Finds the centroid of the index.
+
+
+### h3_cell_to_geography(`h3index`) ⇒ `geography`
+*Since v4.0.0*
+
+
+Finds the centroid of the index.
+
+
+### h3_cell_to_boundary_geometry(`h3index`) ⇒ `geometry`
+*Since v4.0.0*
+
+
+Finds the boundary of the index.
+
+Splits polygons when crossing 180th meridian.
+
+
+### h3_cell_to_boundary_geography(`h3index`) ⇒ `geography`
+*Since v4.0.0*
+
+
+Finds the boundary of the index.
+
+Splits polygons when crossing 180th meridian.
+
+
+# PostGIS Grid Traversal Functions
+
+### h3_grid_path_cells_recursive(origin `h3index`, destination `h3index`) ⇒ SETOF `h3index`
+*Since vunreleased*
+
+
+# PostGIS Region Functions
+
+### h3_polygon_to_cells(multi `geometry`, resolution `integer`) ⇒ SETOF `h3index`
+*Since v4.0.0*
+
+
+### h3_polygon_to_cells(multi `geography`, resolution `integer`) ⇒ SETOF `h3index`
+*Since v4.0.0*
+
+
+### h3_cells_to_multi_polygon_geometry(`h3index[]`) ⇒ `geometry`
+*Since vunreleased*
+
+
+### h3_cells_to_multi_polygon_geography(`h3index[]`) ⇒ `geography`
+*Since vunreleased*
+
+
+### h3_cells_to_multi_polygon_geometry(setof `h3index`)
+*Since vunreleased*
+
+
+### h3_cells_to_multi_polygon_geography(setof `h3index`)
+*Since vunreleased*
+
+
+# PostGIS casts
+
+### `h3index` :: `geometry`
+*Since v0.3.0*
+
+
+### `h3index` :: `geography`
+*Since v0.3.0*
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,111 +1,3 @@
-<!-- start table of contents -->
-**
-
-
-- [API Reference](#api-reference)
-- [Base type](#base-type)
-- [Indexing functions](#indexing-functions)
-  - [h3_lat_lng_to_cell(latlng `point`, resolution `integer`) ⇒ `h3index`](#h3_lat_lng_to_celllatlng-point-resolution-integer--h3index)
-  - [h3_cell_to_lat_lng(cell `h3index`) ⇒ `point`](#h3_cell_to_lat_lngcell-h3index--point)
-  - [h3_cell_to_boundary(cell `h3index`) ⇒ `polygon`](#h3_cell_to_boundarycell-h3index--polygon)
-- [Index inspection functions](#index-inspection-functions)
-  - [h3_get_resolution(`h3index`) ⇒ `integer`](#h3_get_resolutionh3index--integer)
-  - [h3_get_base_cell_number(`h3index`) ⇒ `integer`](#h3_get_base_cell_numberh3index--integer)
-  - [h3_is_valid_cell(`h3index`) ⇒ `boolean`](#h3_is_valid_cellh3index--boolean)
-  - [h3_is_res_class_iii(`h3index`) ⇒ `boolean`](#h3_is_res_class_iiih3index--boolean)
-  - [h3_is_pentagon(`h3index`) ⇒ `boolean`](#h3_is_pentagonh3index--boolean)
-  - [h3_get_icosahedron_faces(`h3index`) ⇒ `integer[]`](#h3_get_icosahedron_facesh3index--integer)
-- [Grid traversal functions](#grid-traversal-functions)
-  - [h3_grid_disk(origin `h3index`, [k `integer` = 1]) ⇒ SETOF `h3index`](#h3_grid_diskorigin-h3index-k-integer--1--setof-h3index)
-  - [h3_grid_disk_distances(origin `h3index`, [k `integer` = 1], OUT index `h3index`, OUT distance `int`) ⇒ SETOF `record`](#h3_grid_disk_distancesorigin-h3index-k-integer--1-out-index-h3index-out-distance-int--setof-record)
-  - [h3_grid_ring_unsafe(origin `h3index`, [k `integer` = 1]) ⇒ SETOF `h3index`](#h3_grid_ring_unsafeorigin-h3index-k-integer--1--setof-h3index)
-  - [h3_grid_path_cells(origin `h3index`, destination `h3index`) ⇒ SETOF `h3index`](#h3_grid_path_cellsorigin-h3index-destination-h3index--setof-h3index)
-  - [h3_grid_distance(origin `h3index`, destination `h3index`) ⇒ `bigint`](#h3_grid_distanceorigin-h3index-destination-h3index--bigint)
-  - [h3_cell_to_local_ij(origin `h3index`, index `h3index`) ⇒ `point`](#h3_cell_to_local_ijorigin-h3index-index-h3index--point)
-  - [h3_local_ij_to_cell(origin `h3index`, coord `point`) ⇒ `h3index`](#h3_local_ij_to_cellorigin-h3index-coord-point--h3index)
-- [Hierarchical grid functions](#hierarchical-grid-functions)
-  - [h3_cell_to_parent(cell `h3index`, resolution `integer`) ⇒ `h3index`](#h3_cell_to_parentcell-h3index-resolution-integer--h3index)
-  - [h3_cell_to_children(cell `h3index`, resolution `integer`) ⇒ SETOF `h3index`](#h3_cell_to_childrencell-h3index-resolution-integer--setof-h3index)
-  - [h3_cell_to_center_child(cell `h3index`, resolution `integer`) ⇒ `h3index`](#h3_cell_to_center_childcell-h3index-resolution-integer--h3index)
-  - [h3_compact_cells(cells `h3index[]`) ⇒ SETOF `h3index`](#h3_compact_cellscells-h3index--setof-h3index)
-  - [h3_uncompact_cells(cells `h3index[]`, resolution `integer`) ⇒ SETOF `h3index`](#h3_uncompact_cellscells-h3index-resolution-integer--setof-h3index)
-  - [h3_cell_to_parent(cell `h3index`) ⇒ `h3index`](#h3_cell_to_parentcell-h3index--h3index)
-  - [h3_cell_to_children(cell `h3index`) ⇒ SETOF `h3index`](#h3_cell_to_childrencell-h3index--setof-h3index)
-  - [h3_cell_to_center_child(cell `h3index`) ⇒ `h3index`](#h3_cell_to_center_childcell-h3index--h3index)
-  - [h3_uncompact_cells(cells `h3index[]`) ⇒ SETOF `h3index`](#h3_uncompact_cellscells-h3index--setof-h3index)
-  - [h3_cell_to_children_slow(index `h3index`, resolution `integer`) ⇒ SETOF `h3index`](#h3_cell_to_children_slowindex-h3index-resolution-integer--setof-h3index)
-  - [h3_cell_to_children_slow(index `h3index`) ⇒ SETOF `h3index`](#h3_cell_to_children_slowindex-h3index--setof-h3index)
-- [Region functions](#region-functions)
-  - [h3_polygon_to_cells(exterior `polygon`, holes `polygon[]`, [resolution `integer` = 1]) ⇒ SETOF `h3index`](#h3_polygon_to_cellsexterior-polygon-holes-polygon-resolution-integer--1--setof-h3index)
-  - [h3_cells_to_multi_polygon(`h3index[]`, OUT exterior `polygon`, OUT holes `polygon[]`) ⇒ SETOF `record`](#h3_cells_to_multi_polygonh3index-out-exterior-polygon-out-holes-polygon--setof-record)
-- [Unidirectional edge functions](#unidirectional-edge-functions)
-  - [h3_are_neighbor_cells(origin `h3index`, destination `h3index`) ⇒ `boolean`](#h3_are_neighbor_cellsorigin-h3index-destination-h3index--boolean)
-  - [h3_cells_to_directed_edge(origin `h3index`, destination `h3index`) ⇒ `h3index`](#h3_cells_to_directed_edgeorigin-h3index-destination-h3index--h3index)
-  - [h3_is_valid_directed_edge(edge `h3index`) ⇒ `boolean`](#h3_is_valid_directed_edgeedge-h3index--boolean)
-  - [h3_get_directed_edge_origin(edge `h3index`) ⇒ `h3index`](#h3_get_directed_edge_originedge-h3index--h3index)
-  - [h3_get_directed_edge_destination(edge `h3index`) ⇒ `h3index`](#h3_get_directed_edge_destinationedge-h3index--h3index)
-  - [h3_directed_edge_to_cells(edge `h3index`, OUT origin `h3index`, OUT destination `h3index`) ⇒ `record`](#h3_directed_edge_to_cellsedge-h3index-out-origin-h3index-out-destination-h3index--record)
-  - [h3_origin_to_directed_edges(`h3index`) ⇒ SETOF `h3index`](#h3_origin_to_directed_edgesh3index--setof-h3index)
-  - [h3_directed_edge_to_boundary(edge `h3index`) ⇒ `polygon`](#h3_directed_edge_to_boundaryedge-h3index--polygon)
-- [H3 Vertex functions](#h3-vertex-functions)
-  - [h3_cell_to_vertex(cell `h3index`, vertexNum `integer`) ⇒ `h3index`](#h3_cell_to_vertexcell-h3index-vertexnum-integer--h3index)
-  - [h3_cell_to_vertexes(cell `h3index`) ⇒ SETOF `h3index`](#h3_cell_to_vertexescell-h3index--setof-h3index)
-  - [h3_vertex_to_lat_lng(vertex `h3index`) ⇒ `point`](#h3_vertex_to_lat_lngvertex-h3index--point)
-  - [h3_is_valid_vertex(vertex `h3index`) ⇒ `boolean`](#h3_is_valid_vertexvertex-h3index--boolean)
-- [Miscellaneous H3 functions](#miscellaneous-h3-functions)
-  - [h3_great_circle_distance(a `point`, b `point`, [unit `text` = km]) ⇒ `double precision`](#h3_great_circle_distancea-point-b-point-unit-text--km--double-precision)
-  - [h3_get_hexagon_area_avg(resolution `integer`, [unit `text` = km]) ⇒ `double precision`](#h3_get_hexagon_area_avgresolution-integer-unit-text--km--double-precision)
-  - [h3_cell_area(cell `h3index`, [unit `text` = km^2]) ⇒ `double precision`](#h3_cell_areacell-h3index-unit-text--km2--double-precision)
-  - [h3_get_hexagon_edge_length_avg(resolution `integer`, [unit `text` = km]) ⇒ `double precision`](#h3_get_hexagon_edge_length_avgresolution-integer-unit-text--km--double-precision)
-  - [h3_edge_length(edge `h3index`, [unit `text` = km]) ⇒ `double precision`](#h3_edge_lengthedge-h3index-unit-text--km--double-precision)
-  - [h3_get_num_cells(resolution `integer`) ⇒ `bigint`](#h3_get_num_cellsresolution-integer--bigint)
-  - [h3_get_res_0_cells() ⇒ SETOF `h3index`](#h3_get_res_0_cells--setof-h3index)
-  - [h3_get_pentagons(resolution `integer`) ⇒ SETOF `h3index`](#h3_get_pentagonsresolution-integer--setof-h3index)
-- [Operators](#operators)
-  - [B-tree operators](#b-tree-operators)
-    - [Operator: `h3index` = `h3index`](#operator-h3index--h3index)
-    - [Operator: `h3index` <> `h3index`](#operator-h3index--h3index)
-  - [R-tree Operators](#r-tree-operators)
-    - [Operator: `h3index` && `h3index`](#operator-h3index--h3index)
-    - [Operator: `h3index` @> `h3index`](#operator-h3index--h3index)
-    - [Operator: `h3index` <@ `h3index`](#operator-h3index--h3index)
-    - [Operator: `h3index` <-> `h3index`](#operator-h3index---h3index)
-- [Type casts](#type-casts)
-  - [`h3index` :: `bigint`](#h3index--bigint)
-  - [`bigint` :: `h3index`](#bigint--h3index)
-  - [`h3index` :: `point`](#h3index--point)
-- [Extension specific functions](#extension-specific-functions)
-  - [h3_get_extension_version() ⇒ `text`](#h3_get_extension_version--text)
-- [WKB indexing functions](#wkb-indexing-functions)
-  - [h3_cell_to_boundary_wkb(cell `h3index`) ⇒ `bytea`](#h3_cell_to_boundary_wkbcell-h3index--bytea)
-- [WKB regions functions](#wkb-regions-functions)
-  - [h3_cells_to_multi_polygon_wkb(`h3index[]`) ⇒ `bytea`](#h3_cells_to_multi_polygon_wkbh3index--bytea)
-- [Deprecated functions](#deprecated-functions)
-  - [h3_cell_to_boundary(cell `h3index`, extend_antimeridian `boolean`) ⇒ `polygon`](#h3_cell_to_boundarycell-h3index-extend_antimeridian-boolean--polygon)
-- [PostGIS Integration](#postgis-integration)
-- [PostGIS Indexing Functions](#postgis-indexing-functions)
-  - [h3_lat_lng_to_cell(`geometry`, resolution `integer`) ⇒ `h3index`](#h3_lat_lng_to_cellgeometry-resolution-integer--h3index)
-  - [h3_lat_lng_to_cell(`geography`, resolution `integer`) ⇒ `h3index`](#h3_lat_lng_to_cellgeography-resolution-integer--h3index)
-  - [h3_cell_to_geometry(`h3index`) ⇒ `geometry`](#h3_cell_to_geometryh3index--geometry)
-  - [h3_cell_to_geography(`h3index`) ⇒ `geography`](#h3_cell_to_geographyh3index--geography)
-  - [h3_cell_to_boundary_geometry(`h3index`) ⇒ `geometry`](#h3_cell_to_boundary_geometryh3index--geometry)
-  - [h3_cell_to_boundary_geography(`h3index`) ⇒ `geography`](#h3_cell_to_boundary_geographyh3index--geography)
-- [PostGIS Grid Traversal Functions](#postgis-grid-traversal-functions)
-  - [h3_grid_path_cells_recursive(origin `h3index`, destination `h3index`) ⇒ SETOF `h3index`](#h3_grid_path_cells_recursiveorigin-h3index-destination-h3index--setof-h3index)
-- [PostGIS Region Functions](#postgis-region-functions)
-  - [h3_polygon_to_cells(multi `geometry`, resolution `integer`) ⇒ SETOF `h3index`](#h3_polygon_to_cellsmulti-geometry-resolution-integer--setof-h3index)
-  - [h3_polygon_to_cells(multi `geography`, resolution `integer`) ⇒ SETOF `h3index`](#h3_polygon_to_cellsmulti-geography-resolution-integer--setof-h3index)
-  - [h3_cells_to_multi_polygon_geometry(`h3index[]`) ⇒ `geometry`](#h3_cells_to_multi_polygon_geometryh3index--geometry)
-  - [h3_cells_to_multi_polygon_geography(`h3index[]`) ⇒ `geography`](#h3_cells_to_multi_polygon_geographyh3index--geography)
-  - [h3_cells_to_multi_polygon_geometry(setof `h3index`)](#h3_cells_to_multi_polygon_geometrysetof-h3index)
-  - [h3_cells_to_multi_polygon_geography(setof `h3index`)](#h3_cells_to_multi_polygon_geographysetof-h3index)
-- [PostGIS casts](#postgis-casts)
-  - [`h3index` :: `geometry`](#h3index--geometry)
-  - [`h3index` :: `geography`](#h3index--geography)
-
-<!-- end table of contents -->
-
-
 # API Reference
 
 # Base type
@@ -125,7 +17,7 @@ and for finding the center and boundary of H3 indexes.
 ### h3_lat_lng_to_cell(latlng `point`, resolution `integer`) ⇒ `h3index`
 *Since v4.0.0*
 
-See also: <a href="#h3_lat_lng_to_cellgeometry-resolution-integer--h3index">h3_lat_lng_to_cell(`geometry`, `integer`)</a>, <a href="#h3_lat_lng_to_cellgeography-resolution-integer--h3index">h3_lat_lng_to_cell(`geography`, `integer`)</a>
+See also: <a href="#h3_lat_lng_to_cell.geometry.resolution.integer.h3index">h3_lat_lng_to_cell(`geometry`, `integer`)</a>, <a href="#h3_lat_lng_to_cell.geography.resolution.integer.h3index">h3_lat_lng_to_cell(`geography`, `integer`)</a>
 
 
 Indexes the location at the specified resolution.
@@ -134,7 +26,7 @@ Indexes the location at the specified resolution.
 ### h3_cell_to_lat_lng(cell `h3index`) ⇒ `point`
 *Since v4.0.0*
 
-See also: <a href="#h3_cell_to_geometryh3index--geometry">h3_cell_to_geometry(`h3index`)</a>, <a href="#h3_cell_to_geographyh3index--geography">h3_cell_to_geography(`h3index`)</a>
+See also: <a href="#h3_cell_to_geometry.h3index.geometry">h3_cell_to_geometry(`h3index`)</a>, <a href="#h3_cell_to_geography.h3index.geography">h3_cell_to_geography(`h3index`)</a>
 
 
 Finds the centroid of the index.
@@ -143,7 +35,7 @@ Finds the centroid of the index.
 ### h3_cell_to_boundary(cell `h3index`) ⇒ `polygon`
 *Since v4.0.0*
 
-See also: <a href="#h3_cell_to_boundary_geometryh3index--geometry">h3_cell_to_boundary_geometry(`h3index`)</a>, <a href="#h3_cell_to_boundary_geographyh3index--geography">h3_cell_to_boundary_geography(`h3index`)</a>
+See also: <a href="#h3_cell_to_boundary_geometry.h3index.geometry">h3_cell_to_boundary_geometry(`h3index`)</a>, <a href="#h3_cell_to_boundary_geography.h3index.geography">h3_cell_to_boundary_geography(`h3index`)</a>
 
 
 Finds the boundary of the index.
@@ -225,6 +117,8 @@ Returns the hollow hexagonal ring centered at origin with distance "k".
 
 ### h3_grid_path_cells(origin `h3index`, destination `h3index`) ⇒ SETOF `h3index`
 *Since v4.0.0*
+
+See also: <a href="#h3_grid_path_cells_recursive.origin.h3index.destination.h3index.SETOF.h3index">h3_grid_path_cells_recursive(`h3index`, `h3index`)</a>
 
 
 Given two H3 indexes, return the line of indexes between them (inclusive).
@@ -341,12 +235,16 @@ These functions convert H3 indexes to and from polygonal areas.
 ### h3_polygon_to_cells(exterior `polygon`, holes `polygon[]`, [resolution `integer` = 1]) ⇒ SETOF `h3index`
 *Since v4.0.0*
 
+See also: <a href="#h3_polygon_to_cells.multi.geometry.resolution.integer.SETOF.h3index">h3_polygon_to_cells(`geometry`, `integer`)</a>, <a href="#h3_polygon_to_cells.multi.geography.resolution.integer.SETOF.h3index">h3_polygon_to_cells(`geography`, `integer`)</a>
+
 
 Takes an exterior polygon [and a set of hole polygon] and returns the set of hexagons that best fit the structure.
 
 
 ### h3_cells_to_multi_polygon(`h3index[]`, OUT exterior `polygon`, OUT holes `polygon[]`) ⇒ SETOF `record`
 *Since v4.0.0*
+
+See also: <a href="#h3_cells_to_multi_polygon_geometry.h3index.geometry">h3_cells_to_multi_polygon_geometry(`h3index[]`)</a>, <a href="#h3_cells_to_multi_polygon_geography.h3index.geography">h3_cells_to_multi_polygon_geography(`h3index[]`)</a>, <a href="#h3_cells_to_multi_polygon_geometry.setof.h3index.">h3_cells_to_multi_polygon_geometry(setof `h3index`)</a>, <a href="#h3_cells_to_multi_polygon_geography.setof.h3index.">h3_cells_to_multi_polygon_geography(setof `h3index`)</a>
 
 
 Create a LinkedGeoPolygon describing the outline(s) of a set of hexagons. Polygon outlines will follow GeoJSON MultiPolygon order: Each polygon will have one outer loop, which is first in the list, followed by any holes.

--- a/h3/sql/install/01-indexing.sql
+++ b/h3/sql/install/01-indexing.sql
@@ -20,6 +20,7 @@
 --| and for finding the center and boundary of H3 indexes.
 
 --@ availability: 4.0.0
+--@ ref: h3_lat_lng_to_cell_geometry, h3_lat_lng_to_cell_geography
 CREATE OR REPLACE FUNCTION
     h3_lat_lng_to_cell(latlng point, resolution integer) RETURNS h3index
 AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
@@ -27,6 +28,7 @@ AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
 IS 'Indexes the location at the specified resolution.';
 
 --@ availability: 4.0.0
+--@ ref: h3_cell_to_geometry, h3_cell_to_geography
 CREATE OR REPLACE FUNCTION
     h3_cell_to_lat_lng(cell h3index) RETURNS point
 AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
@@ -34,6 +36,7 @@ AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
 IS 'Finds the centroid of the index.';
 
 --@ availability: 4.0.0
+--@ ref: h3_cell_to_boundary_geometry, h3_cell_to_boundary_geography
 CREATE OR REPLACE FUNCTION
     h3_cell_to_boundary(cell h3index) RETURNS polygon
 AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION

--- a/h3/sql/install/03-traversal.sql
+++ b/h3/sql/install/03-traversal.sql
@@ -41,6 +41,7 @@ AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
 IS 'Returns the hollow hexagonal ring centered at origin with distance "k".';
 
 --@ availability: 4.0.0
+--@ ref: h3_grid_path_cells_recursive
 CREATE OR REPLACE FUNCTION
     h3_grid_path_cells(origin h3index, destination h3index) RETURNS SETOF h3index
 AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION

--- a/h3/sql/install/05-regions.sql
+++ b/h3/sql/install/05-regions.sql
@@ -19,6 +19,7 @@
 --| These functions convert H3 indexes to and from polygonal areas.
 
 --@ availability: 4.0.0
+--@ ref: h3_polygon_to_cells_geometry, h3_polygon_to_cells_geography
 CREATE OR REPLACE FUNCTION
     h3_polygon_to_cells(exterior polygon, holes polygon[], resolution integer DEFAULT 1) RETURNS SETOF h3index
 AS 'h3' LANGUAGE C IMMUTABLE
@@ -28,6 +29,7 @@ CALLED ON NULL INPUT PARALLEL SAFE; COMMENT ON FUNCTION
 IS 'Takes an exterior polygon [and a set of hole polygon] and returns the set of hexagons that best fit the structure.';
 
 --@ availability: 4.0.0
+--@ ref: h3_cells_to_multi_polygon_geometry, h3_cells_to_multi_polygon_geography, h3_cells_to_multi_polygon_geometry_agg, h3_cells_to_multi_polygon_geography_agg
 CREATE OR REPLACE FUNCTION
     h3_cells_to_multi_polygon(h3index[], OUT exterior polygon, OUT holes polygon[]) RETURNS SETOF record
 AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION

--- a/h3_postgis/sql/install/01-indexing.sql
+++ b/h3_postgis/sql/install/01-indexing.sql
@@ -17,6 +17,7 @@
 --| # PostGIS Indexing Functions
 
 --@ availability: 4.0.0
+--@ refid: h3_lat_lng_to_cell_geometry
 CREATE OR REPLACE FUNCTION h3_lat_lng_to_cell(geometry, resolution integer) RETURNS h3index
     AS $$ SELECT h3_lat_lng_to_cell($1::point, $2); $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
 COMMENT ON FUNCTION
@@ -24,6 +25,7 @@ COMMENT ON FUNCTION
 IS 'Indexes the location at the specified resolution.';
 
 --@ availability: 4.0.0
+--@ refid: h3_lat_lng_to_cell_geography
 CREATE OR REPLACE FUNCTION h3_lat_lng_to_cell(geography, resolution integer) RETURNS h3index
     AS $$ SELECT h3_lat_lng_to_cell($1::geometry, $2); $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
 COMMENT ON FUNCTION
@@ -31,6 +33,7 @@ COMMENT ON FUNCTION
 IS 'Indexes the location at the specified resolution.';
 
 --@ availability: 4.0.0
+--@ refid: h3_cell_to_geometry
 CREATE OR REPLACE FUNCTION h3_cell_to_geometry(h3index) RETURNS geometry
   AS $$ SELECT ST_SetSRID(h3_cell_to_lat_lng($1)::geometry, 4326) $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
 COMMENT ON FUNCTION
@@ -38,6 +41,7 @@ COMMENT ON FUNCTION
 IS 'Finds the centroid of the index.';
 
 --@ availability: 4.0.0
+--@ refid: h3_cell_to_geography
 CREATE OR REPLACE FUNCTION h3_cell_to_geography(h3index) RETURNS geography
   AS $$ SELECT h3_cell_to_geometry($1)::geography $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
 COMMENT ON FUNCTION
@@ -45,6 +49,7 @@ COMMENT ON FUNCTION
 IS 'Finds the centroid of the index.';
 
 --@ availability: 4.0.0
+--@ refid: h3_cell_to_boundary_geometry
 CREATE OR REPLACE FUNCTION h3_cell_to_boundary_geometry(h3index) RETURNS geometry
   AS $$ SELECT h3_cell_to_boundary_wkb($1)::geometry $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
 COMMENT ON FUNCTION
@@ -54,6 +59,7 @@ IS 'Finds the boundary of the index.
 Splits polygons when crossing 180th meridian.';
 
 --@ availability: 4.0.0
+--@ refid: h3_cell_to_boundary_geography
 CREATE OR REPLACE FUNCTION h3_cell_to_boundary_geography(h3index) RETURNS geography
   AS $$ SELECT h3_cell_to_boundary_wkb($1)::geography $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
 COMMENT ON FUNCTION

--- a/h3_postgis/sql/install/03-traversal.sql
+++ b/h3_postgis/sql/install/03-traversal.sql
@@ -17,6 +17,7 @@
 --| # PostGIS Grid Traversal Functions
 
 --@ availability: unreleased
+--@ refid: h3_grid_path_cells_recursive
 CREATE OR REPLACE FUNCTION
     h3_grid_path_cells_recursive(origin h3index, destination h3index) RETURNS SETOF h3index
 AS $$

--- a/h3_postgis/sql/install/05-regions.sql
+++ b/h3_postgis/sql/install/05-regions.sql
@@ -17,6 +17,7 @@
 --| # PostGIS Region Functions
 
 --@ availability: 4.0.0
+--@ refid: h3_polygon_to_cells_geometry
 CREATE OR REPLACE FUNCTION h3_polygon_to_cells(multi geometry, resolution integer) RETURNS SETOF h3index
     AS $$ SELECT h3_polygon_to_cells(exterior, holes, resolution) FROM (
         SELECT 
@@ -38,20 +39,24 @@ CREATE OR REPLACE FUNCTION h3_polygon_to_cells(multi geometry, resolution intege
     ) h3_polygon_to_cells; $$ LANGUAGE SQL IMMUTABLE PARALLEL SAFE CALLED ON NULL INPUT; -- NOT STRICT
 
 --@ availability: 4.0.0
+--@ refid: h3_polygon_to_cells_geography
 CREATE OR REPLACE FUNCTION h3_polygon_to_cells(multi geography, resolution integer) RETURNS SETOF h3index
 AS $$ SELECT h3_polygon_to_cells($1::geometry, $2) $$ LANGUAGE SQL IMMUTABLE PARALLEL SAFE CALLED ON NULL INPUT; -- NOT STRICT
 
 --@ availability: unreleased
+--@ refid: h3_cells_to_multi_polygon_geometry
 CREATE OR REPLACE FUNCTION
     h3_cells_to_multi_polygon_geometry(h3index[]) RETURNS geometry
 AS $$ SELECT h3_cells_to_multi_polygon_wkb($1)::geometry $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
 
 --@ availability: unreleased
+--@ refid: h3_cells_to_multi_polygon_geography
 CREATE OR REPLACE FUNCTION
     h3_cells_to_multi_polygon_geography(h3index[]) RETURNS geography
 AS $$ SELECT h3_cells_to_multi_polygon_wkb($1)::geography $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
 
 --@ availability: unreleased
+--@ refid: h3_cells_to_multi_polygon_geometry_agg
 CREATE OR REPLACE AGGREGATE h3_cells_to_multi_polygon_geometry(h3index) (
     sfunc = array_append,
     stype = h3index[],
@@ -60,6 +65,7 @@ CREATE OR REPLACE AGGREGATE h3_cells_to_multi_polygon_geometry(h3index) (
 );
 
 --@ availability: unreleased
+--@ refid: h3_cells_to_multi_polygon_geography_agg
 CREATE OR REPLACE AGGREGATE h3_cells_to_multi_polygon_geography(h3index) (
     sfunc = array_append,
     stype = h3index[],

--- a/h3_postgis/sql/install/20-casts.sql
+++ b/h3_postgis/sql/install/20-casts.sql
@@ -15,7 +15,7 @@
  */
 
 -- ---------- ---------- ---------- ---------- ---------- ---------- ----------
---| ## PostGIS casts
+--| # PostGIS casts
 
 --@ availability: 0.3.0
 CREATE CAST (h3index AS geometry) WITH FUNCTION h3_cell_to_geometry(h3index);

--- a/h3_postgis/sql/install/99-deprecated.sql
+++ b/h3_postgis/sql/install/99-deprecated.sql
@@ -15,9 +15,11 @@
  */
 
 --@ availability: 4.0.0
+--@ deprecated
 CREATE OR REPLACE FUNCTION h3_cell_to_boundary_geometry(h3index, extend_antimeridian boolean) RETURNS geometry
   AS $$ SELECT ST_SetSRID(h3_cell_to_boundary($1, extend_antimeridian)::geometry, 4326) $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
 
 --@ availability: 4.0.0
+--@ deprecated
 CREATE OR REPLACE FUNCTION h3_cell_to_boundary_geography(h3index, extend_antimeridian boolean) RETURNS geography
   AS $$ SELECT ST_SetSRID(h3_cell_to_boundary($1, extend_antimeridian)::geometry, 4326) $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;

--- a/scripts/documentation.sh
+++ b/scripts/documentation.sh
@@ -10,7 +10,7 @@ cd documentation
 poetry install
 
 # generate markdown from sql files
-poetry run -q -- python generate.py "../../h3/sql/install/*.sql" > "../../docs/api.md"
-
-# include table of contents
-npx doctoc "../../docs/api.md"
+poetry run -q -- python generate.py \
+       -g "API Reference" "../../h3/sql/install/*.sql" \
+       -g "PostGIS Integration" "../../h3_postgis/sql/install/*.sql" \
+       > "../../docs/api.md"

--- a/scripts/documentation/generate.py
+++ b/scripts/documentation/generate.py
@@ -1,3 +1,28 @@
+"""
+The concept:
+
+We don't want to manually keep API docs in sync with SQL files.
+
+So instead we should generate the docs from the sql/install/*.sql files.
+
+We have the following things to document:
+    * Type
+    * Cast (put in same section as the type)
+    * Operator
+    * Function
+    * Aggregate function
+
+Some functions do not need docs, we can signal this by not applying a comment.
+This is internal operator functions for example.
+
+We should parse the sql files, extract the above, and then document all things that
+have comments applied.
+
+We should probably hardcode a list of things that should not be documented, so we can
+fail if new function are undocumented.
+
+"""
+
 import argparse
 import glob
 import re

--- a/scripts/documentation/generate.py
+++ b/scripts/documentation/generate.py
@@ -1,33 +1,234 @@
+import argparse
 import glob
+import re
 import sys
 from pathlib import Path
+from lark import Lark, Transformer, v_args, visitors
 
-from lark import Lark, Transformer, Visitor, v_args, Transformer
+TocIndent = 2
+
+def to_anchor(text):
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"\s", "-", text)
+    return "#" + text.lower()
+
+def toc_item(text, level=0):
+    link = "[{}]({})".format(text, to_anchor(text))
+    return " " * (TocIndent * level) + "- " + link
+
+def md_heading(text, level=0):
+    return "#" * (level + 1) + " " + text
+
+class Context:
+    level = 0
+
+    def __init__(self, statements_by_refid={}):
+        self.statements_by_refid = statements_by_refid
+        self.level = 0
+
+class StmtBase:
+    level = 0
+    newline_before = True
+    newline_after = True
+    decorators = {}
+
+    def __init__(self, level=-1):
+        self.level = level
+
+    def set_decorators(self, decorators):
+        self.decorators = decorators
+
+    def get_decorator(self, key):
+        return self.decorators[key] if self.has_decorator(key) else None
+
+    def has_decorator(self, key):
+        return key in self.decorators
+
+    def is_internal(self):
+        return self.has_decorator("internal")
+
+    def is_deprecated(self):
+        return self.has_decorator("deprecated")
+
+    def is_visible(self):
+        return not self.is_internal() and not self.is_deprecated()
+
+    def get_refid(self):
+        return self.get_decorator("refid")
+
+    def get_ref_text(self):
+        return str(self)
+
+    def get_anchor(self):
+        if not self.is_visible() or self.level < 0:
+            return None
+        return to_anchor(str(self))
+
+    def get_refs(self, statements_by_refid):
+        ids = self.get_decorator("ref") or []
+        return [statements_by_refid[refid] for refid in ids if refid in statements_by_refid]
+
+    def to_ref(self):
+        return '<a href="{}">{}</a>'.format(self.get_anchor(), self.get_ref_text())
+
+    def to_toc(self, context):
+        if not self.is_visible() or self.level < 0:
+            return ""
+        return toc_item(str(self), min(context.level + 1, self.level))
+
+    def to_md(self, context):
+        if not self.is_visible():
+            return ""
+
+        md = str(self)
+        if self.level > -1:
+            md = md_heading(md, self.level)
+
+        if self.newline_before:
+            md = "\n" + md
+
+        # availability
+        availability = self.get_decorator("availability")
+        if availability:
+            md += f"\n*Since v{availability}*"
+
+        # references
+        refs = self.get_refs(context.statements_by_refid)
+        if len(refs) > 0:
+            md += "\n\nSee also: "
+            md += ", ".join([ref.to_ref() for ref in refs])
+
+        if self.newline_after:
+            md += "\n"
+
+        return md
+
+    def __str__(self):
+        raise Execepion("Not implemented")
 
 
-class Function:
-    def __init__(self, name: str, arguments, returntype: str, returns_set: bool):
+class Argument:
+    def __init__(self, argmode, name, argtype, default):
+        self.argmode = argmode
         self.name = name
-        self.arguments = arguments
+        self.argtype = argtype
+        self.default = default
+
+    def get_typestr(self):
+        s = "`{}`".format(self.argtype)
+        if self.default:
+            s = "[{} = {}]".format(s, self.default)
+        return s
+
+    def __str__(self):
+        s = ""
+        if self.argmode:
+            s += self.argmode + " "
+        if self.name:
+            s += self.name + " "
+        s += "`{}`".format(self.argtype)
+        if self.default:
+            s = "[{} = {}]".format(s, self.default)
+        return s
+
+
+class CustomMd(StmtBase):
+    def __init__(self, line):
+        super().__init__()
+        self.newline_after = False
+        match = re.match(r"(#+)\s*(.*)", line)
+        if match:
+            self.newline_before = True
+            self.level = max(0, len(match[1]) - 1)
+            self.line = match[2]
+        else:
+            self.newline_before = False
+            self.level = -1
+            self.line = line
+
+    def update_level(self, context):
+        if self.level > -1:
+            context.level = max(0, self.level)
+
+    def to_toc(self, context):
+        toc = super().to_toc(context)
+        self.update_level(context)
+        return toc
+
+    def __str__(self):
+        return self.line
+
+
+class CreateFunctionStmt(StmtBase):
+    def __init__(self, name: str, arguments, returntype: str, returns_set: bool):
+        super().__init__(2)
+        self.name = name
+        self.arguments = arguments or []
         self.returntype = returntype
         self.returns_set = returns_set
 
+    def get_ref_text(self):
+        return "{}({})".format(
+            self.name,
+            ", ".join([arg.get_typestr() for arg in self.arguments]))
+
     def __str__(self):
-        if self.name.startswith("__"):
-            return None
-        if self.arguments is None:
-            self.arguments = []
-        return "\n### {}({}) ⇒ {}`{}`".format(
-            self.name, ", ".join(self.arguments),
+        return "{}({}) ⇒ {}`{}`".format(
+            self.name,
+            ", ".join([str(arg) for arg in self.arguments]),
             "SETOF " if self.returns_set else "",
-            self.returntype
-        )
+            self.returntype)
 
 
-def get_deco(decorators, key):
-    if decorators and key in decorators:
-        return decorators[key]
-    return None
+class CreateAggregateStmt(StmtBase):
+    def __init__(self, name: str, arguments):
+        super().__init__(2)
+        self.name = name
+        self.arguments = arguments or []
+
+    def get_ref_text(self):
+        return "{}(setof {})".format(
+            self.name,
+            ", ".join([arg.get_typestr() for arg in self.arguments]))
+
+    def __str__(self):
+        return "{}(setof {})".format(
+            self.name,
+            ", ".join([str(arg) for arg in self.arguments]))
+
+
+class CreateTypeStmt(StmtBase):
+    def __str__(self):
+        return ""
+
+class CreateCastStmt(StmtBase):
+    def __init__(self, source, target):
+        super().__init__(2)
+        self.source = source
+        self.target = target
+
+    def __str__(self):
+        return "`{}` :: `{}`".format(self.source, self.target)
+
+
+class CreateOperatorStmt(StmtBase):
+    def __init__(self, name, left, right):
+        super().__init__(2)
+        self.name = name
+        self.left = left
+        self.right = right
+
+    def __str__(self):
+        return "Operator: `{}` {} `{}`".format(self.left, self.name, self.right)
+
+
+class CreateCommentStmt(StmtBase):
+    def __init__(self, text):
+        super().__init__()
+        self.text = text
+
+    def __str__(self):
+        return self.text
 
 
 class SQLTransformer(Transformer):
@@ -37,22 +238,23 @@ class SQLTransformer(Transformer):
         return flat
 
     @v_args(inline=True)
-    def custom_decorated_statement(self, decorators, statement):
-        text = str(statement)
-        availability = get_deco(decorators, "availability")
-        if get_deco(decorators, "internal") or get_deco(decorators, "deprecated"):
-            return ""
-        if availability:
-            text += f"\n*Since v{availability}*"
-        text += "\n\n"
-        return text
+    def custom_decorated_statement(self, decorators, statement = None):
+        if not statement:
+            raise visitors.Discard()
+        if decorators:
+            statement.set_decorators(decorators)
+        return statement
 
     def custom_decorators(self, lines):
         decorators = {}
         for line in lines:
             try:
                 key, value = line.split(":")
-                decorators[str(key).lower()] = value.strip()
+                key = str(key).lower()
+                if key in ["ref"]:
+                    decorators[key] = [v.strip() for v in value.split(",")]
+                else:
+                    decorators[key] = value.strip()
             except:
                 decorators[str(line).lower()] = True
         return decorators
@@ -60,36 +262,34 @@ class SQLTransformer(Transformer):
     def custom_md_statement(self, children):
         return children
 
-    # -- MARKDOWN --------------------------------------------------------------
     @v_args(inline=True)
     def custom_markdown(self, line=""):
-        return "" + line
+        return CustomMd(line)
 
-    # -- CREATE TYPE -----------------------------------------------------------
     def create_type_stmt(self, children):
-        return ""
+        return CreateTypeStmt()
 
-    # -- CREATE CAST -----------------------------------------------------------
     @v_args(inline=True)
     def create_cast_stmt(self, source, target, *children):
-        return f"### `{source}` :: `{target}`"
+        return CreateCastStmt(source, target)
 
-    # -- CREATE OPERATOR -------------------------------------------------------
     @v_args(inline=True)
     def create_oper_stmt(self, name, options):
-        return f"### Operator: `{options['LEFTARG']}` {name} `{options['RIGHTARG']}`"
+        return CreateOperatorStmt(name, options['LEFTARG'], options['RIGHTARG'])
 
     def create_oper_opts(self, opts):
-        options = {}
-        for [k, v] in opts:
-            options[k] = v
-        return options
+        return {key: value for [key, value] in opts}
 
     @v_args(inline=True)
     def create_oper_opt(self, option, value=None):
         return [str(option), value]
 
-    # -- CREATE FUNCTION -------------------------------------------------------
+    def create_opcl_stmt(self, children):
+        raise visitors.Discard()
+
+    def fun_name(self, children):
+        return children[1]
+
     def create_fun_rettype(self, children):
         # (returntype, returns_set)
         return (children[1], children[0] is not None)
@@ -98,39 +298,23 @@ class SQLTransformer(Transformer):
     def create_func_stmt(self, name: str, arguments, returntype, *opts):
         # skip internal functions
         if name.startswith("__"):
-            return None
+            raise visitors.Discard()
+        return CreateFunctionStmt(name, arguments, returntype[0], returntype[1])
 
-        # print("func")
-
-        return Function(name, arguments, returntype[0], returntype[1])
+    @v_args(inline=True)
+    def create_agg_stmt(self, name: str, arguments, *params):
+        return CreateAggregateStmt(name, arguments)
 
     def argument_list(self, children):
         return children
 
-    # -- CREATE COMMENT --------------------------------------------------------
+    @v_args(inline=True)
+    def argument(self, argmode, name, argtype, default=None):
+        return Argument(argmode, name, argtype, default)
+
     @v_args(inline=True)
     def comment_on_stmt(self, child, text):
-        child["type"] = "comment"
-        child["text"] = text
-        # print(child)
-        return text
-
-    # ... ON CAST
-    @v_args(inline=True)
-    def comment_on_cast(self, source, target):
-        return {"on": "cast", "source": source, "target": target}
-
-    # ... ON FUNCTION
-    @v_args(inline=True)
-    def comment_on_function(self, name, arguments):
-        return {"on": "function", "name": name, "arguments": arguments}
-
-    # ... ON OPERATOR
-    @v_args(inline=True)
-    def comment_on_operator(self, name, left, right):
-        return {"on": "operator", "name": name, "left": left, "right": right}
-
-    # -- SIMPLE RULES ----------------------------------------------------------
+        return CreateCommentStmt(text)
 
     true = lambda self, _: "`true`"
     false = lambda self, _: "`false`"
@@ -139,23 +323,6 @@ class SQLTransformer(Transformer):
     @v_args(inline=True)
     def string(self, s):
         return s[1:-1].replace('\\"', '"')
-
-    def fun_name(self, children):
-        return children[1]
-
-    @v_args(inline=True)
-    def argument(self, argmode, name, argtype, default=None):
-        out = ""
-        if argmode:
-            out += "{} ".format(argmode)
-        if name:
-            out += name + " "
-        out += "`{}`".format(argtype)
-        if default:
-            out = "[{} = {}]".format(out, default)
-        return out
-
-    # -- TERMINALS -------------------------------------------------------------
 
     def SIGNED_NUMBER(self, children):
         return int(children)
@@ -167,48 +334,80 @@ class SQLTransformer(Transformer):
         return str(name)
 
 
-"""
-The concept:
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--group', '-g',
+        nargs=2, metavar=('header', 'glob'),
+        action='append',
+        help='Globs for each group of SQL install files')
+    return parser.parse_args()
 
-We don't want to manually keep API docs in sync with SQL files.
-
-So instead we should generate the docs from the sql/install/*.sql files.
-
-We have the following things to document:
-    * Type
-    * Cast (put in same section as the type)
-    * Operator
-    * Function
-
-Some functions do not need docs, we can signal this by not applying a comment.
-This is internal operator functions for example.
-
-We should parse the sql files, extract the above, and then document all things that
-have comments applied.
-
-We should probably hardcode a list of things that should not be documented, so we can
-fail if new function are undocumented.
-
-"""
-
-
-if __name__ == "__main__":
+def create_parser():
     here = Path(__file__).parent
-
     parser = Lark.open(
         here / "sql.lark",
         parser="lalr",
-        maybe_placeholders=True,
-    )
+        maybe_placeholders=True)
+    return parser
 
-    files = glob.glob(sys.argv[1])
-    markdown = "# API Reference\n\n"
+def process_group(parser, group, statements_by_refid):
+    [header, files_glob] = group
+    statements = []
+    paths = glob.glob(files_glob)
+    for path in sorted(paths):
+        group_statements = parse_file(parser, path)
+        # Add referenced statements to map
+        for statement in group_statements:
+            refid = statement.get_refid()
+            if refid:
+                statements_by_refid[refid] = statement
+        statements += group_statements
+    return (header, statements)
 
-    for file in sorted(files):
-        with open(file) as f:
-            sql = f.read()
-            parse_tree = parser.parse(sql)
-            statements = SQLTransformer(visit_tokens=True).transform(parse_tree)
-            markdown += "\n".join([str(stmt) for stmt in statements])
+# return flat list of statements in file
+def parse_file(parser, path):
+    with open(path) as fd:
+        sql = fd.read()
+        tree = parser.parse(sql)
+        statements = SQLTransformer(visit_tokens=True).transform(tree)
+        return statements
 
-    print(markdown)
+def statements_to_toc(statements, context):
+    items = [stmt.to_toc(context) for stmt in statements]
+    return [item for item in items if len(item) > 0]
+
+def statements_to_md(statements, context):
+    items = [stmt.to_md(context) for stmt in statements]
+    return [item for item in items if len(item) > 0]
+
+def main():
+    args = parse_args()
+    parser = create_parser()
+
+    groups = []
+    statements_by_refid = {}
+
+    # Process groups
+    for item in args.group:
+        group = process_group(parser, item, statements_by_refid)
+        groups.append(group)
+
+    # Output
+    toc = ""
+    md = ""
+    for group in groups:
+        [header, statements] = group
+        toc += toc_item(header) + "\n"
+        toc += "\n".join(statements_to_toc(statements, Context())) + "\n"
+        md += md_heading(header) + "\n"
+        md += "\n".join(statements_to_md(statements, Context(statements_by_refid))) + "\n"
+
+    print("<!-- start table of contents -->");
+    print("**\n\n")
+    print(toc)
+    print("<!-- end table of contents -->\n\n");
+    print(md)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/documentation/sql.lark
+++ b/scripts/documentation/sql.lark
@@ -12,6 +12,7 @@ custom_decorated_statement: [custom_decorators] statement
           | create_opcl_stmt
           | create_oper_stmt
           | create_func_stmt
+          | create_agg_stmt
           | comment_on_stmt
 
 custom_decorators: ("--@" /([^\n])+/)+
@@ -83,13 +84,44 @@ create_oper_opts: create_oper_opt ("," create_oper_opt)*
 //     [ WITH ( attribute [, ...] ) ]
 create_func_stmt: "CREATE" ("OR" "REPLACE")? "FUNCTION" fun_name "(" [argument_list] ")" [create_fun_rets] create_fun_opts*
 ?create_fun_rets: "RETURNS" create_fun_rettype
-create_fun_opts: "LANGUAGE" CNAME
+create_fun_opts: "LANGUAGE" (CNAME|"'" CNAME "'")
               | ("IMMUTABLE" | "STABLE" | "VOLATILE" | ("NOT"? "LEAKPROOF"))
               | (("CALLED" "ON" "NULL" "INPUT") | ("RETURNS" "NULL" "ON" "NULL" "INPUT") | "STRICT")
               | ("PARALLEL" ("UNSAFE" | "RESTRICTED" | "SAFE"))
               | "AS" string ("," string)?
 argument_list: argument ("," argument)*
 !create_fun_rettype: ["SETOF"] DATATYPE
+
+// -----------------------------------------------------------------------------
+// CREATE [ OR REPLACE ] AGGREGATE name ( [ argmode ] [ argname ] arg_data_type [ , ... ] ) (
+//     SFUNC = sfunc,
+//     STYPE = state_data_type
+//     [ , SSPACE = state_data_size ]
+//     [ , FINALFUNC = ffunc ]
+//     [ , FINALFUNC_EXTRA ]
+//     [ , FINALFUNC_MODIFY = { READ_ONLY | SHAREABLE | READ_WRITE } ]
+//     [ , COMBINEFUNC = combinefunc ]
+//     [ , SERIALFUNC = serialfunc ]
+//     [ , DESERIALFUNC = deserialfunc ]
+//     [ , INITCOND = initial_condition ]
+//     [ , MSFUNC = msfunc ]
+//     [ , MINVFUNC = minvfunc ]
+//     [ , MSTYPE = mstate_data_type ]
+//     [ , MSSPACE = mstate_data_size ]
+//     [ , MFINALFUNC = mffunc ]
+//     [ , MFINALFUNC_EXTRA ]
+//     [ , MFINALFUNC_MODIFY = { READ_ONLY | SHAREABLE | READ_WRITE } ]
+//     [ , MINITCOND = minitial_condition ]
+//     [ , SORTOP = sort_operator ]
+//     [ , PARALLEL = { SAFE | RESTRICTED | UNSAFE } ]
+// )
+// create_agg_stmt: "CREATE" ("OR" "REPLACE")? "AGGREGATE" fun_name "(" [argument_list] ")" "(" agg_param_list ")"
+create_agg_stmt: "CREATE" ("OR" "REPLACE")? "AGGREGATE" fun_name "(" [argument_list] ")" "(" agg_param_list ")"
+agg_param_list: agg_param ("," agg_param)*
+agg_param: "sfunc" "=" fun_name
+         | "stype" "=" DATATYPE
+         | "finalfunc" "=" fun_name
+         | "parallel" "=" ("safe"|"restricted"|"unsafe")
 
 // -----------------------------------------------------------------------------
 // COMMENT ON
@@ -109,7 +141,7 @@ comment_on_type: "CAST" "(" DATATYPE "AS" DATATYPE ")" -> comment_on_cast
 
 // -----------------------------------------------------------------------------
 // SIMPLE RULES
-argument: [ARGMODE] [CNAME] DATATYPE "[]"? ("DEFAULT" expr)?
+argument: [ARGMODE] [CNAME] DATATYPE ("DEFAULT" expr)?
 ARGMODE.2: "IN" | "OUT" | "INOUT"
 DATATYPE_SCALAR: "h3index"
         | "bigint"


### PR DESCRIPTION
… generation

Work in progress.

* Table of contents generation moved to `generate.py`, links now work on Github;
* "PostGIS Integration" section added;
* Function cross-references ("See also: ...") added for indexing functions.

Generating table of contents and references for both extensions in single script allows to create cross-references between functions, directing users to PostGIS wrapper if it exists.
![xref](https://user-images.githubusercontent.com/1970037/201872374-6f4047c7-8c7e-4e75-892b-9e8ec2d18585.png)


Currently, a bug (?) in [Text::Markdown](https://metacpan.org/release/BOBTFISH/Text-Markdown-1.000031/source/lib/Text/Markdown.pm#L455) causes ToC generated by doctoc to be removed on PGXN:
![no-toc](https://user-images.githubusercontent.com/1970037/201871086-b6fe3df0-6da3-4de3-a32b-55e0ba1f443d.png)


Since "See also: ..." links can work either on Github or PGXN, I suggest removing ToC generation altogether and instead point users to PGXN for API reference.
