### PR TITLE
Add migration helper for pass-by-val (fixes #31)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -474,6 +474,13 @@ Convert H3 index to point.
 Get the currently installed version of the extension.
 
 
+### h3_pg_migrate_pass_by_reference(`h3index`) ⇒ `h3index`
+*Since vunreleased*
+
+
+Migrate h3index from pass-by-reference to pass-by-value.
+
+
 # Deprecated functions
 
 ### h3_cell_to_boundary(cell `h3index`, extend_antimeridian `boolean`) ⇒ `polygon`

--- a/h3/sql/install/30-extension.sql
+++ b/h3/sql/install/30-extension.sql
@@ -21,3 +21,9 @@ CREATE OR REPLACE FUNCTION h3_get_extension_version() RETURNS text
     AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
     COMMENT ON FUNCTION h3_get_extension_version() IS
 'Get the currently installed version of the extension.';
+
+--@ availability: unreleased
+CREATE OR REPLACE FUNCTION h3_pg_migrate_pass_by_reference(h3index) RETURNS h3index
+    AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+    COMMENT ON FUNCTION h3_pg_migrate_pass_by_reference(h3index) IS
+'Migrate h3index from pass-by-reference to pass-by-value.';

--- a/h3/sql/updates/h3--4.0.3--unreleased.sql
+++ b/h3/sql/updates/h3--4.0.3--unreleased.sql
@@ -25,3 +25,8 @@ ALTER OPERATOR CLASS  btree_h3index_ops USING btree RENAME TO h3index_ops;
 
 ALTER OPERATOR FAMILY hash_h3index_ops USING hash RENAME TO h3index_ops;
 ALTER OPERATOR CLASS  hash_h3index_ops USING hash RENAME TO h3index_ops;
+
+CREATE OR REPLACE FUNCTION h3_pg_migrate_pass_by_reference(h3index) RETURNS h3index
+    AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+    COMMENT ON FUNCTION h3_pg_migrate_pass_by_reference(h3index) IS
+'Migrate h3index from pass-by-reference to pass-by-value.';

--- a/h3/src/extension.c
+++ b/h3/src/extension.c
@@ -31,6 +31,7 @@
 PG_MODULE_MAGIC;
 
 PGDLLEXPORT PG_FUNCTION_INFO_V1(h3_get_extension_version);
+PGDLLEXPORT PG_FUNCTION_INFO_V1(h3_pg_migrate_pass_by_reference);
 
 /* Return version number for this extension (not main h3 lib) */
 Datum
@@ -141,4 +142,16 @@ srf_return_h3_index_distances_from_user_fctx(PG_FUNCTION_ARGS)
 	{
 		SRF_RETURN_DONE(funcctx);
 	}
+}
+
+/*
+ * Migration from pass-by-reference to pass-by-value
+ * https://github.com/zachasme/h3-pg/issues/31
+ */
+Datum
+h3_pg_migrate_pass_by_reference(PG_FUNCTION_ARGS)
+{
+	H3Index		cell = (*((H3Index *) DatumGetPointer(PG_GETARG_DATUM(0))));
+
+	PG_RETURN_H3INDEX(cell);
 }


### PR DESCRIPTION
It's been more than two years, so probably no-one will ever use this, but I finally understood how to provide a helper function to fix the pass-by-reference into pass-by-value migration.