### PR TITLE
Add support for binary i/o

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cargo
-          key: ${{ runner.os }}-cargo-2023
+          key: ${{ runner.os }}-cargo-2024
 
       - name: Install pg_validate_extupgrade
         run: cargo install --locked --git https://github.com/rjuju/pg_validate_extupgrade.git

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         config: [Release, Debug]
-        pg: [15, 14, 13, 12, 11]
+        pg: [16, 15, 14, 13]
 
     runs-on: ubuntu-22.04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ avoid adding features or APIs which do not map onto the
     Click to see more.
   </summary>
 
+- Add support for binary I/O (see [#160], thanks [@robertozimek])
+
 </details>
 
 ## [4.1.3] - 2023-07-26
@@ -258,6 +260,7 @@ avoid adding features or APIs which do not map onto the
 [#112]: https://github.com/zachasme/h3-pg/pull/112
 [#117]: https://github.com/zachasme/h3-pg/issues/117
 [#131]: https://github.com/zachasme/h3-pg/pull/131
+[#160]: https://github.com/zachasme/h3-pg/pull/160
 [@abelvm]: https://github.com/AbelVM
 [@kalenikaliaksandr]: https://github.com/kalenikaliaksandr
 [@kmacdough]: https://github.com/kmacdough
@@ -266,3 +269,4 @@ avoid adding features or APIs which do not map onto the
 [@mngr777]: https://github.com/mngr777
 [@trylinka]: https://github.com/trylinka
 [@rustprooflabs]: https://github.com/rustprooflabs
+[@robertozimek]: https://github.com/robertozimek

--- a/h3/sql/install/00-type.sql
+++ b/h3/sql/install/00-type.sql
@@ -44,8 +44,20 @@ CREATE OR REPLACE FUNCTION
     h3index_out(h3index) RETURNS cstring
 AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+--@ internal
+CREATE OR REPLACE FUNCTION
+    h3index_recv(internal) RETURNS h3index
+AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+--@ internal
+CREATE OR REPLACE FUNCTION
+    h3index_send(h3index) RETURNS bytea
+AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE TYPE h3index (
   INPUT          = h3index_in,
   OUTPUT         = h3index_out,
+  RECEIVE        = h3index_recv,
+  SEND           = h3index_send,
   LIKE           = int8
 );

--- a/h3/sql/updates/h3--4.1.3--unreleased.sql
+++ b/h3/sql/updates/h3--4.1.3--unreleased.sql
@@ -24,10 +24,10 @@ AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 --@ internal
 CREATE OR REPLACE FUNCTION
-    h3index_send(h3index) RETURNS byta
+    h3index_send(h3index) RETURNS bytea
 AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 ALTER TYPE h3index SET (
     RECEIVE        = h3index_recv,
     SEND           = h3index_send
-    );
+);

--- a/h3/sql/updates/h3--4.1.3--unreleased.sql
+++ b/h3/sql/updates/h3--4.1.3--unreleased.sql
@@ -16,3 +16,18 @@
 
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "ALTER EXTENSION h3 UPDATE TO 'unreleased'" to load this file. \quit
+
+--@ internal
+CREATE OR REPLACE FUNCTION
+    h3index_recv(internal) RETURNS h3index
+AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+--@ internal
+CREATE OR REPLACE FUNCTION
+    h3index_send(h3index) RETURNS byta
+AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+ALTER TYPE h3index SET (
+    RECEIVE        = h3index_recv,
+    SEND           = h3index_send
+    );

--- a/h3/sql/updates/h3--4.1.3--unreleased.sql
+++ b/h3/sql/updates/h3--4.1.3--unreleased.sql
@@ -28,6 +28,6 @@ CREATE OR REPLACE FUNCTION
 AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 ALTER TYPE h3index SET (
-    RECEIVE        = h3index_recv,
-    SEND           = h3index_send
+    RECEIVE = h3index_recv,
+    SEND    = h3index_send
 );

--- a/h3/src/binding/indexing.c
+++ b/h3/src/binding/indexing.c
@@ -24,6 +24,7 @@
 
 #include <fmgr.h>			 // PG_FUNCTION_INFO_V1
 #include <utils/geo_decls.h> // PG_GETARG_POINT_P
+#include <math.h> // fabs
 
 #include "constants.h"
 #include "error.h"

--- a/h3/src/type.c
+++ b/h3/src/type.c
@@ -59,7 +59,7 @@ h3index_recv(PG_FUNCTION_ARGS)
 {
 	StringInfo	buf = (StringInfo) PG_GETARG_POINTER(0);
 
-	PG_RETURN_POINTER(pq_getmsgint64(buf));
+	PG_RETURN_H3INDEX(pq_getmsgint64(buf));
 }
 
 Datum

--- a/h3/src/type.c
+++ b/h3/src/type.c
@@ -58,25 +58,18 @@ Datum
 h3index_recv(PG_FUNCTION_ARGS)
 {
 	StringInfo	buf = (StringInfo) PG_GETARG_POINTER(0);
-	H3Index		h3;
 
-	const char *string = pq_getmsgstring(buf);
-	h3_assert(stringToH3(string, &h3));
-
-	PG_RETURN_POINTER(h3);
+	PG_RETURN_POINTER(pq_getmsgint64(buf));
 }
 
 Datum
 h3index_send(PG_FUNCTION_ARGS)
 {
 	H3Index		h3 = PG_GETARG_H3INDEX(0);
-	char	   *string = palloc(17 * sizeof(char));
-
-	h3_assert(h3ToString(h3, string, 17));
 	StringInfoData buf;
 
 	pq_begintypsend(&buf);
-	pq_sendstring(&buf, string);
+	pq_sendint64(&buf, h3);
 
 	PG_RETURN_BYTEA_P(pq_endtypsend(&buf));
 }

--- a/h3/test/CMakeLists.txt
+++ b/h3/test/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 if(PostgreSQL_VALIDATE_EXTUPGRADE)
   add_test(
-    NAME h3_validate_extrupgrade
+    NAME h3_validate_extupgrade
     COMMAND pg_validate_extupgrade
       --extname h3
       --from 0.1.0

--- a/h3/test/expected/type.out
+++ b/h3/test/expected/type.out
@@ -38,9 +38,31 @@ SELECT :hexagon = :asbigint::h3index;
 --
 -- TEST binary io
 --
-COPY (SELECT :hexagon) TO '/tmp/test.bin' (FORMAT binary);
-CREATE TEMPORARY TABLE tmp (val h3index);
-COPY tmp FROM '/tmp/test.bin' (FORMAT binary);
-SELECT val = :hexagon FROM tmp WHERE val = :hexagon;
+CREATE OR REPLACE FUNCTION copy_to_and_from_file(index h3index) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
+$$
+DECLARE
+    result BOOL;
+BEGIN
+    CREATE TEMPORARY TABLE from_temp (val h3index);
+    INSERT INTO from_temp (val) VALUES (index);
+    CREATE TEMPORARY TABLE to_tmp (val h3index);
+    IF (
+        SELECT CASE setting WHEN 'windows' THEN true ELSE false END AS isWindows
+        FROM pg_catalog.pg_file_settings
+        WHERE name = 'dynamic_shared_memory_type'
+    )
+    THEN
+        COPY (SELECT val FROM from_temp) TO 'C:\Windows\Temp\test.bin' (FORMAT binary);
+        COPY to_tmp FROM 'C:\Windows\Temp\test.bin' (FORMAT binary);
+    ELSE
+        COPY (SELECT val FROM from_temp) TO '/tmp/test.bin' (FORMAT binary);
+        COPY to_tmp FROM '/tmp/test.bin' (FORMAT binary);
+    END IF;
+
+    SELECT val = index into result FROM to_tmp WHERE val = index;
+    RETURN result;
+END;
+$$;
+SELECT copy_to_and_from_file(:hexagon);
  t
 

--- a/h3/test/expected/type.out
+++ b/h3/test/expected/type.out
@@ -49,8 +49,8 @@ CREATE FUNCTION h3_test_binary_io() RETURNS boolean LANGUAGE PLPGSQL AS $$
         -- base temp dir on platform
         IF (SELECT setting = 'windows' FROM pg_catalog.pg_file_settings WHERE name = 'dynamic_shared_memory_type')
         THEN
-            COPY h3_test_binary_send TO '%localappdata%\Temp\h3_test_binary.bin' (FORMAT binary);
-            COPY h3_test_binary_recv FROM '%localappdata%\Temp\h3_test_binary.bin' (FORMAT binary);
+            COPY h3_test_binary_send TO 'C:\Windows\Temp\h3_test_binary.bin' (FORMAT binary);
+            COPY h3_test_binary_recv FROM 'C:\Windows\Temp\h3_test_binary.bin' (FORMAT binary);
         ELSE
             COPY h3_test_binary_send TO '/tmp/h3_test_binary.bin' (FORMAT binary);
             COPY h3_test_binary_recv FROM '/tmp/h3_test_binary.bin' (FORMAT binary);

--- a/h3/test/expected/type.out
+++ b/h3/test/expected/type.out
@@ -35,3 +35,12 @@ SELECT :asbigint = :hexagon::bigint;
 SELECT :hexagon = :asbigint::h3index;
  t
 
+--
+-- TEST binary io
+--
+COPY (SELECT :hexagon) TO '/tmp/test.bin' (FORMAT binary);
+CREATE TEMPORARY TABLE tmp (val h3index);
+COPY tmp FROM '/tmp/test.bin' (FORMAT binary);
+SELECT val = :hexagon FROM tmp WHERE val = :hexagon;
+ t
+

--- a/h3/test/expected/type.out
+++ b/h3/test/expected/type.out
@@ -38,15 +38,33 @@ SELECT :hexagon = :asbigint::h3index;
 --
 -- TEST binary io
 --
-CREATE TEMPORARY TABLE h3_test_binary_send (hex h3index PRIMARY KEY);
-CREATE TEMPORARY TABLE h3_test_binary_recv (hex h3index PRIMARY KEY);
-INSERT INTO h3_test_binary_send (hex) SELECT * from h3_get_res_0_cells();
-COPY h3_test_binary_send TO '/tmp/h3_test_binary.bin' (FORMAT binary);
-COPY h3_test_binary_recv FROM '/tmp/h3_test_binary.bin' (FORMAT binary);
--- same data after re-import
-SELECT array_agg(hex) is null FROM (
-	SELECT hex FROM h3_test_binary_send
-	EXCEPT SELECT hex FROM h3_test_binary_recv
-) q;
+CREATE FUNCTION h3_test_binary_io() RETURNS boolean LANGUAGE PLPGSQL AS $$
+    DECLARE
+        result boolean;
+    BEGIN
+        CREATE TEMPORARY TABLE h3_test_binary_send (hex h3index PRIMARY KEY);
+        CREATE TEMPORARY TABLE h3_test_binary_recv (hex h3index PRIMARY KEY);
+        INSERT INTO h3_test_binary_send (hex) SELECT * from h3_get_res_0_cells();
+
+        -- base temp dir on platform
+        IF (SELECT setting = 'windows' FROM pg_catalog.pg_file_settings WHERE name = 'dynamic_shared_memory_type')
+        THEN
+            COPY h3_test_binary_send TO '%localappdata%\Temp\h3_test_binary.bin' (FORMAT binary);
+            COPY h3_test_binary_recv FROM '%localappdata%\Temp\h3_test_binary.bin' (FORMAT binary);
+        ELSE
+            COPY h3_test_binary_send TO '/tmp/h3_test_binary.bin' (FORMAT binary);
+            COPY h3_test_binary_recv FROM '/tmp/h3_test_binary.bin' (FORMAT binary);
+        END IF;
+
+        -- same data after re-import
+        SELECT array_agg(hex) is null INTO result FROM (
+            SELECT hex FROM h3_test_binary_send
+            EXCEPT SELECT hex FROM h3_test_binary_recv
+        ) q;
+
+        RETURN result;
+    END
+$$;
+SELECT h3_test_binary_io();
  t
 

--- a/h3/test/expected/type.out
+++ b/h3/test/expected/type.out
@@ -38,31 +38,15 @@ SELECT :hexagon = :asbigint::h3index;
 --
 -- TEST binary io
 --
-CREATE OR REPLACE FUNCTION copy_to_and_from_file(index h3index) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
-$$
-DECLARE
-result BOOL;
-BEGIN
-    CREATE TEMPORARY TABLE from_temp (val h3index);
-    INSERT INTO from_temp (val) VALUES (index);
-    CREATE TEMPORARY TABLE to_tmp (val h3index);
-    IF (
-        SELECT CASE setting WHEN 'windows' THEN true ELSE false END AS isWindows
-        FROM pg_catalog.pg_file_settings
-        WHERE name = 'dynamic_shared_memory_type'
-    )
-    THEN
-        COPY (SELECT val FROM from_temp) TO 'C:\Windows\Temp\test.bin' (FORMAT binary);
-        COPY to_tmp FROM 'C:\Windows\Temp\test.bin' (FORMAT binary);
-    ELSE
-        COPY (SELECT val FROM from_temp) TO '/tmp/test.bin' (FORMAT binary);
-        COPY to_tmp FROM '/tmp/test.bin' (FORMAT binary);
-    END IF;
-
-    SELECT val = index into result FROM to_tmp WHERE val = index;
-RETURN result;
-END;
-$$;
-SELECT copy_to_and_from_file(:hexagon);
+CREATE TEMPORARY TABLE h3_test_binary_send (hex h3index PRIMARY KEY);
+CREATE TEMPORARY TABLE h3_test_binary_recv (hex h3index PRIMARY KEY);
+INSERT INTO h3_test_binary_send (hex) SELECT * from h3_get_res_0_cells();
+COPY h3_test_binary_send TO '/tmp/h3_test_binary.bin' (FORMAT binary);
+COPY h3_test_binary_recv FROM '/tmp/h3_test_binary.bin' (FORMAT binary);
+-- same data after re-import
+SELECT array_agg(hex) is null FROM (
+	SELECT hex FROM h3_test_binary_send
+	EXCEPT SELECT hex FROM h3_test_binary_recv
+) q;
  t
 

--- a/h3/test/expected/type.out
+++ b/h3/test/expected/type.out
@@ -38,33 +38,16 @@ SELECT :hexagon = :asbigint::h3index;
 --
 -- TEST binary io
 --
-CREATE FUNCTION h3_test_binary_io() RETURNS boolean LANGUAGE PLPGSQL AS $$
-    DECLARE
-        result boolean;
-    BEGIN
-        CREATE TEMPORARY TABLE h3_test_binary_send (hex h3index PRIMARY KEY);
-        CREATE TEMPORARY TABLE h3_test_binary_recv (hex h3index PRIMARY KEY);
-        INSERT INTO h3_test_binary_send (hex) SELECT * from h3_get_res_0_cells();
-
-        -- base temp dir on platform
-        IF (SELECT setting = 'windows' FROM pg_catalog.pg_file_settings WHERE name = 'dynamic_shared_memory_type')
-        THEN
-            COPY h3_test_binary_send TO 'C:\Windows\Temp\h3_test_binary.bin' (FORMAT binary);
-            COPY h3_test_binary_recv FROM 'C:\Windows\Temp\h3_test_binary.bin' (FORMAT binary);
-        ELSE
-            COPY h3_test_binary_send TO '/tmp/h3_test_binary.bin' (FORMAT binary);
-            COPY h3_test_binary_recv FROM '/tmp/h3_test_binary.bin' (FORMAT binary);
-        END IF;
-
-        -- same data after re-import
-        SELECT array_agg(hex) is null INTO result FROM (
-            SELECT hex FROM h3_test_binary_send
-            EXCEPT SELECT hex FROM h3_test_binary_recv
-        ) q;
-
-        RETURN result;
-    END
-$$;
-SELECT h3_test_binary_io();
+CREATE TEMPORARY TABLE h3_test_binary_send (hex h3index PRIMARY KEY);
+CREATE TEMPORARY TABLE h3_test_binary_recv (hex h3index PRIMARY KEY);
+INSERT INTO h3_test_binary_send (hex) SELECT * from h3_get_res_0_cells();
+-- we need to use \copy instead of SQL COPY in order to have relative path
+\copy h3_test_binary_send TO 'h3_test_binary.bin' (FORMAT binary)
+\copy h3_test_binary_recv FROM 'h3_test_binary.bin' (FORMAT binary)
+-- make sure re-imported data matches original data
+SELECT array_agg(hex) is null FROM (
+    SELECT hex FROM h3_test_binary_send
+    EXCEPT SELECT hex FROM h3_test_binary_recv
+) q;
  t
 

--- a/h3/test/expected/type.out
+++ b/h3/test/expected/type.out
@@ -41,7 +41,7 @@ SELECT :hexagon = :asbigint::h3index;
 CREATE OR REPLACE FUNCTION copy_to_and_from_file(index h3index) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
 $$
 DECLARE
-    result BOOL;
+result BOOL;
 BEGIN
     CREATE TEMPORARY TABLE from_temp (val h3index);
     INSERT INTO from_temp (val) VALUES (index);
@@ -60,7 +60,7 @@ BEGIN
     END IF;
 
     SELECT val = index into result FROM to_tmp WHERE val = index;
-    RETURN result;
+RETURN result;
 END;
 $$;
 SELECT copy_to_and_from_file(:hexagon);

--- a/h3/test/sql/type.sql
+++ b/h3/test/sql/type.sql
@@ -26,14 +26,31 @@ SELECT :hexagon = :asbigint::h3index;
 --
 -- TEST binary io
 --
-CREATE TEMPORARY TABLE h3_test_binary_send (hex h3index PRIMARY KEY);
-CREATE TEMPORARY TABLE h3_test_binary_recv (hex h3index PRIMARY KEY);
-INSERT INTO h3_test_binary_send (hex) SELECT * from h3_get_res_0_cells();
-COPY h3_test_binary_send TO '/tmp/h3_test_binary.bin' (FORMAT binary);
-COPY h3_test_binary_recv FROM '/tmp/h3_test_binary.bin' (FORMAT binary);
+CREATE FUNCTION h3_test_binary_io() RETURNS boolean LANGUAGE PLPGSQL AS $$
+    DECLARE
+        result boolean;
+    BEGIN
+        CREATE TEMPORARY TABLE h3_test_binary_send (hex h3index PRIMARY KEY);
+        CREATE TEMPORARY TABLE h3_test_binary_recv (hex h3index PRIMARY KEY);
+        INSERT INTO h3_test_binary_send (hex) SELECT * from h3_get_res_0_cells();
 
--- same data after re-import
-SELECT array_agg(hex) is null FROM (
-	SELECT hex FROM h3_test_binary_send
-	EXCEPT SELECT hex FROM h3_test_binary_recv
-) q;
+        -- base temp dir on platform
+        IF (SELECT setting = 'windows' FROM pg_catalog.pg_file_settings WHERE name = 'dynamic_shared_memory_type')
+        THEN
+            COPY h3_test_binary_send TO '%localappdata%\Temp\h3_test_binary.bin' (FORMAT binary);
+            COPY h3_test_binary_recv FROM '%localappdata%\Temp\h3_test_binary.bin' (FORMAT binary);
+        ELSE
+            COPY h3_test_binary_send TO '/tmp/h3_test_binary.bin' (FORMAT binary);
+            COPY h3_test_binary_recv FROM '/tmp/h3_test_binary.bin' (FORMAT binary);
+        END IF;
+
+        -- same data after re-import
+        SELECT array_agg(hex) is null INTO result FROM (
+            SELECT hex FROM h3_test_binary_send
+            EXCEPT SELECT hex FROM h3_test_binary_recv
+        ) q;
+
+        RETURN result;
+    END
+$$;
+SELECT h3_test_binary_io();

--- a/h3/test/sql/type.sql
+++ b/h3/test/sql/type.sql
@@ -29,7 +29,7 @@ SELECT :hexagon = :asbigint::h3index;
 CREATE OR REPLACE FUNCTION copy_to_and_from_file(index h3index) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
 $$
 DECLARE
-    result BOOL;
+result BOOL;
 BEGIN
     CREATE TEMPORARY TABLE from_temp (val h3index);
     INSERT INTO from_temp (val) VALUES (index);
@@ -40,15 +40,15 @@ BEGIN
         WHERE name = 'dynamic_shared_memory_type'
     )
     THEN
-        COPY (SELECT val FROM from_temp) TO 'D:\a\h3-pg\test.bin' (FORMAT binary);
-        COPY to_tmp FROM 'D:\a\h3-pg\test.bin' (FORMAT binary);
+        COPY (SELECT val FROM from_temp) TO 'C:\Windows\Temp\test.bin' (FORMAT binary);
+        COPY to_tmp FROM 'C:\Windows\Temp\test.bin' (FORMAT binary);
     ELSE
         COPY (SELECT val FROM from_temp) TO '/tmp/test.bin' (FORMAT binary);
         COPY to_tmp FROM '/tmp/test.bin' (FORMAT binary);
     END IF;
 
     SELECT val = index into result FROM to_tmp WHERE val = index;
-    RETURN result;
+RETURN result;
 END;
 $$;
 SELECT copy_to_and_from_file(:hexagon);

--- a/h3/test/sql/type.sql
+++ b/h3/test/sql/type.sql
@@ -26,31 +26,16 @@ SELECT :hexagon = :asbigint::h3index;
 --
 -- TEST binary io
 --
-CREATE FUNCTION h3_test_binary_io() RETURNS boolean LANGUAGE PLPGSQL AS $$
-    DECLARE
-        result boolean;
-    BEGIN
-        CREATE TEMPORARY TABLE h3_test_binary_send (hex h3index PRIMARY KEY);
-        CREATE TEMPORARY TABLE h3_test_binary_recv (hex h3index PRIMARY KEY);
-        INSERT INTO h3_test_binary_send (hex) SELECT * from h3_get_res_0_cells();
+CREATE TEMPORARY TABLE h3_test_binary_send (hex h3index PRIMARY KEY);
+CREATE TEMPORARY TABLE h3_test_binary_recv (hex h3index PRIMARY KEY);
+INSERT INTO h3_test_binary_send (hex) SELECT * from h3_get_res_0_cells();
 
-        -- base temp dir on platform
-        IF (SELECT setting = 'windows' FROM pg_catalog.pg_file_settings WHERE name = 'dynamic_shared_memory_type')
-        THEN
-            COPY h3_test_binary_send TO 'C:\Windows\Temp\h3_test_binary.bin' (FORMAT binary);
-            COPY h3_test_binary_recv FROM 'C:\Windows\Temp\h3_test_binary.bin' (FORMAT binary);
-        ELSE
-            COPY h3_test_binary_send TO '/tmp/h3_test_binary.bin' (FORMAT binary);
-            COPY h3_test_binary_recv FROM '/tmp/h3_test_binary.bin' (FORMAT binary);
-        END IF;
+-- we need to use \copy instead of SQL COPY in order to have relative path
+\copy h3_test_binary_send TO 'h3_test_binary.bin' (FORMAT binary)
+\copy h3_test_binary_recv FROM 'h3_test_binary.bin' (FORMAT binary)
 
-        -- same data after re-import
-        SELECT array_agg(hex) is null INTO result FROM (
-            SELECT hex FROM h3_test_binary_send
-            EXCEPT SELECT hex FROM h3_test_binary_recv
-        ) q;
-
-        RETURN result;
-    END
-$$;
-SELECT h3_test_binary_io();
+-- make sure re-imported data matches original data
+SELECT array_agg(hex) is null FROM (
+    SELECT hex FROM h3_test_binary_send
+    EXCEPT SELECT hex FROM h3_test_binary_recv
+) q;

--- a/h3/test/sql/type.sql
+++ b/h3/test/sql/type.sql
@@ -37,8 +37,8 @@ CREATE FUNCTION h3_test_binary_io() RETURNS boolean LANGUAGE PLPGSQL AS $$
         -- base temp dir on platform
         IF (SELECT setting = 'windows' FROM pg_catalog.pg_file_settings WHERE name = 'dynamic_shared_memory_type')
         THEN
-            COPY h3_test_binary_send TO '%localappdata%\Temp\h3_test_binary.bin' (FORMAT binary);
-            COPY h3_test_binary_recv FROM '%localappdata%\Temp\h3_test_binary.bin' (FORMAT binary);
+            COPY h3_test_binary_send TO 'C:\Windows\Temp\h3_test_binary.bin' (FORMAT binary);
+            COPY h3_test_binary_recv FROM 'C:\Windows\Temp\h3_test_binary.bin' (FORMAT binary);
         ELSE
             COPY h3_test_binary_send TO '/tmp/h3_test_binary.bin' (FORMAT binary);
             COPY h3_test_binary_recv FROM '/tmp/h3_test_binary.bin' (FORMAT binary);

--- a/h3/test/sql/type.sql
+++ b/h3/test/sql/type.sql
@@ -26,7 +26,29 @@ SELECT :hexagon = :asbigint::h3index;
 --
 -- TEST binary io
 --
-COPY (SELECT :hexagon) TO '/tmp/test.bin' (FORMAT binary);
-CREATE TEMPORARY TABLE tmp (val h3index);
-COPY tmp FROM '/tmp/test.bin' (FORMAT binary);
-SELECT val = :hexagon FROM tmp WHERE val = :hexagon;
+CREATE OR REPLACE FUNCTION copy_to_and_from_file(index h3index) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
+$$
+DECLARE
+    result BOOL;
+BEGIN
+    CREATE TEMPORARY TABLE from_temp (val h3index);
+    INSERT INTO from_temp (val) VALUES (index);
+    CREATE TEMPORARY TABLE to_tmp (val h3index);
+    IF (
+        SELECT CASE setting WHEN 'windows' THEN true ELSE false END AS isWindows
+        FROM pg_catalog.pg_file_settings
+        WHERE name = 'dynamic_shared_memory_type'
+    )
+    THEN
+        COPY (SELECT val FROM from_temp) TO 'D:\a\h3-pg\test.bin' (FORMAT binary);
+        COPY to_tmp FROM 'D:\a\h3-pg\test.bin' (FORMAT binary);
+    ELSE
+        COPY (SELECT val FROM from_temp) TO '/tmp/test.bin' (FORMAT binary);
+        COPY to_tmp FROM '/tmp/test.bin' (FORMAT binary);
+    END IF;
+
+    SELECT val = index into result FROM to_tmp WHERE val = index;
+    RETURN result;
+END;
+$$;
+SELECT copy_to_and_from_file(:hexagon);

--- a/h3/test/sql/type.sql
+++ b/h3/test/sql/type.sql
@@ -26,29 +26,14 @@ SELECT :hexagon = :asbigint::h3index;
 --
 -- TEST binary io
 --
-CREATE OR REPLACE FUNCTION copy_to_and_from_file(index h3index) RETURNS BOOLEAN LANGUAGE PLPGSQL AS
-$$
-DECLARE
-result BOOL;
-BEGIN
-    CREATE TEMPORARY TABLE from_temp (val h3index);
-    INSERT INTO from_temp (val) VALUES (index);
-    CREATE TEMPORARY TABLE to_tmp (val h3index);
-    IF (
-        SELECT CASE setting WHEN 'windows' THEN true ELSE false END AS isWindows
-        FROM pg_catalog.pg_file_settings
-        WHERE name = 'dynamic_shared_memory_type'
-    )
-    THEN
-        COPY (SELECT val FROM from_temp) TO 'C:\Windows\Temp\test.bin' (FORMAT binary);
-        COPY to_tmp FROM 'C:\Windows\Temp\test.bin' (FORMAT binary);
-    ELSE
-        COPY (SELECT val FROM from_temp) TO '/tmp/test.bin' (FORMAT binary);
-        COPY to_tmp FROM '/tmp/test.bin' (FORMAT binary);
-    END IF;
+CREATE TEMPORARY TABLE h3_test_binary_send (hex h3index PRIMARY KEY);
+CREATE TEMPORARY TABLE h3_test_binary_recv (hex h3index PRIMARY KEY);
+INSERT INTO h3_test_binary_send (hex) SELECT * from h3_get_res_0_cells();
+COPY h3_test_binary_send TO '/tmp/h3_test_binary.bin' (FORMAT binary);
+COPY h3_test_binary_recv FROM '/tmp/h3_test_binary.bin' (FORMAT binary);
 
-    SELECT val = index into result FROM to_tmp WHERE val = index;
-RETURN result;
-END;
-$$;
-SELECT copy_to_and_from_file(:hexagon);
+-- same data after re-import
+SELECT array_agg(hex) is null FROM (
+	SELECT hex FROM h3_test_binary_send
+	EXCEPT SELECT hex FROM h3_test_binary_recv
+) q;

--- a/h3/test/sql/type.sql
+++ b/h3/test/sql/type.sql
@@ -22,3 +22,11 @@ SELECT bool_and(:pentagon @> c) FROM (
 SELECT :asbigint = :hexagon::bigint;
 
 SELECT :hexagon = :asbigint::h3index;
+
+--
+-- TEST binary io
+--
+COPY (SELECT :hexagon) TO '/tmp/test.bin' (FORMAT binary);
+CREATE TEMPORARY TABLE tmp (val h3index);
+COPY tmp FROM '/tmp/test.bin' (FORMAT binary);
+SELECT val = :hexagon FROM tmp WHERE val = :hexagon;


### PR DESCRIPTION
many rust postgres drivers use binary transfer, so would be nice to be able to use h3 indexes without casting them to string.