### PR TITLE
add function h3_get_resolution_from_tile_zoom

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -578,6 +578,13 @@ Finds the boundary of the index.
 Splits polygons when crossing 180th meridian.
 
 
+### h3_get_resolution_from_tile_zoom(z `integer`, [max_h3_resolution `integer` = 15], min_h3_resolution `integer`, [hex_edge_pixels `integer` = 44], [tile_size `integer` = 512]) ⇒ `integer`
+*Since v4.2.3*
+
+
+Returns the optimal H3 resolution for a specified XYZ tile zoom level, based on hexagon size in pixels and resolution limits
+
+
 # PostGIS Grid Traversal Functions
 
 ### h3_grid_path_cells_recursive(origin `h3index`, destination `h3index`) ⇒ SETOF `h3index`

--- a/h3_postgis/sql/updates/h3_postgis--4.2.2--unreleased.sql
+++ b/h3_postgis/sql/updates/h3_postgis--4.2.2--unreleased.sql
@@ -16,3 +16,33 @@
 
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "ALTER EXTENSION h3_postgis UPDATE TO 'unreleased'" to load this file. \quit
+
+CREATE OR REPLACE FUNCTION h3_get_resolution_from_tile_zoom(
+    z integer,
+    max_h3_resolution integer DEFAULT 15,
+    min_h3_resolution integer DEFAULT 0,
+    hex_edge_pixels integer DEFAULT 44,
+    tile_size integer DEFAULT 512
+) RETURNS integer
+AS $$
+DECLARE
+    e0  CONSTANT numeric := h3_get_hexagon_edge_length_avg(0,'m'); -- res-0 edge
+    ln7 CONSTANT numeric := LN(SQRT(7.0));                         -- = ln(√7)
+    desired_edge numeric;
+    r_est        integer;
+BEGIN
+    IF z < 0 THEN
+        RAISE EXCEPTION 'Negative tile zoom levels are not supported';
+    END IF;
+
+    desired_edge := 40075016.6855785 / (tile_size * 2 ^ z) * hex_edge_pixels;
+
+    r_est := ROUND( LN(e0 / desired_edge) / ln7 );
+
+    RETURN GREATEST(min_h3_resolution,
+           LEAST(r_est, max_h3_resolution));
+END;
+$$ LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;
+COMMENT ON FUNCTION
+    h3_get_resolution_from_tile_zoom(integer, integer, integer, integer, integer)
+IS 'Returns the optimal H3 resolution for a specified XYZ tile zoom level, based on hexagon size in pixels and resolution limits';

--- a/h3_postgis/test/expected/postgis.out
+++ b/h3_postgis/test/expected/postgis.out
@@ -140,3 +140,112 @@ SELECT COUNT(*) = 76 FROM (
 ) q;
  t
 
+--
+-- test h3_get_resolution_from_tile_zoom
+--
+-- consequtive examples for tile zooms 0..15 with default params
+--   tile_size: 512 px
+--   hex_edge_pixels: 44
+--   max_h3_resolution: 15
+--   min_h3_resolution: 0
+SELECT h3_get_resolution_from_tile_zoom(0) = 0;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(1) = 0;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(2) = 0;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(3) = 1;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(4) = 2;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(5) = 3;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(6) = 3;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(7) = 4;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(8) = 5;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(9) = 5;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(10) = 6;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(11) = 7;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(12) = 8;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(13) = 8;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(14) = 9;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(15) = 10;
+ t
+
+-- consequtive examples for tile zooms 0..15 with settings:
+--   tile_size: 512 px
+--   hex_edge_pixels: 5
+--   max_h3_resolution: 8
+--   min_h3_resolution: 0
+SELECT h3_get_resolution_from_tile_zoom(0, 8, 0, 5, 512) = 1;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(1, 8, 0, 5, 512) = 2;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(2, 8, 0, 5, 512) = 3;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(3, 8, 0, 5, 512) = 3;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(4, 8, 0, 5, 512) = 4;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(5, 8, 0, 5, 512) = 5;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(6, 8, 0, 5, 512) = 5;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(7, 8, 0, 5, 512) = 6;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(8, 8, 0, 5, 512) = 7;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(9, 8, 0, 5, 512) = 8;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(10, 8, 0, 5, 512) = 8;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(11, 8, 0, 5, 512) = 8;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(12, 8, 0, 5, 512) = 8;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(13, 8, 0, 5, 512) = 8;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(14, 8, 0, 5, 512) = 8;
+ t
+
+SELECT h3_get_resolution_from_tile_zoom(15, 8, 0, 5, 512) = 8;
+ t
+

--- a/h3_postgis/test/sql/postgis.sql
+++ b/h3_postgis/test/sql/postgis.sql
@@ -121,3 +121,53 @@ SELECT COUNT(*) = 48 FROM (
 SELECT COUNT(*) = 76 FROM (
     SELECT h3_polygon_to_cells_experimental(:with2holes, 10, 'overlapping')
 ) q;
+
+--
+-- test h3_get_resolution_from_tile_zoom
+--
+
+-- consequtive examples for tile zooms 0..15 with default params
+--   tile_size: 512 px
+--   hex_edge_pixels: 44
+--   max_h3_resolution: 15
+--   min_h3_resolution: 0
+
+SELECT h3_get_resolution_from_tile_zoom(0) = 0;
+SELECT h3_get_resolution_from_tile_zoom(1) = 0;
+SELECT h3_get_resolution_from_tile_zoom(2) = 0;
+SELECT h3_get_resolution_from_tile_zoom(3) = 1;
+SELECT h3_get_resolution_from_tile_zoom(4) = 2;
+SELECT h3_get_resolution_from_tile_zoom(5) = 3;
+SELECT h3_get_resolution_from_tile_zoom(6) = 3;
+SELECT h3_get_resolution_from_tile_zoom(7) = 4;
+SELECT h3_get_resolution_from_tile_zoom(8) = 5;
+SELECT h3_get_resolution_from_tile_zoom(9) = 5;
+SELECT h3_get_resolution_from_tile_zoom(10) = 6;
+SELECT h3_get_resolution_from_tile_zoom(11) = 7;
+SELECT h3_get_resolution_from_tile_zoom(12) = 8;
+SELECT h3_get_resolution_from_tile_zoom(13) = 8;
+SELECT h3_get_resolution_from_tile_zoom(14) = 9;
+SELECT h3_get_resolution_from_tile_zoom(15) = 10;
+
+-- consequtive examples for tile zooms 0..15 with settings:
+--   tile_size: 512 px
+--   hex_edge_pixels: 5
+--   max_h3_resolution: 8
+--   min_h3_resolution: 0
+
+SELECT h3_get_resolution_from_tile_zoom(0, 8, 0, 5, 512) = 1;
+SELECT h3_get_resolution_from_tile_zoom(1, 8, 0, 5, 512) = 2;
+SELECT h3_get_resolution_from_tile_zoom(2, 8, 0, 5, 512) = 3;
+SELECT h3_get_resolution_from_tile_zoom(3, 8, 0, 5, 512) = 3;
+SELECT h3_get_resolution_from_tile_zoom(4, 8, 0, 5, 512) = 4;
+SELECT h3_get_resolution_from_tile_zoom(5, 8, 0, 5, 512) = 5;
+SELECT h3_get_resolution_from_tile_zoom(6, 8, 0, 5, 512) = 5;
+SELECT h3_get_resolution_from_tile_zoom(7, 8, 0, 5, 512) = 6;
+SELECT h3_get_resolution_from_tile_zoom(8, 8, 0, 5, 512) = 7;
+SELECT h3_get_resolution_from_tile_zoom(9, 8, 0, 5, 512) = 8;
+SELECT h3_get_resolution_from_tile_zoom(10, 8, 0, 5, 512) = 8;
+SELECT h3_get_resolution_from_tile_zoom(11, 8, 0, 5, 512) = 8;
+SELECT h3_get_resolution_from_tile_zoom(12, 8, 0, 5, 512) = 8;
+SELECT h3_get_resolution_from_tile_zoom(13, 8, 0, 5, 512) = 8;
+SELECT h3_get_resolution_from_tile_zoom(14, 8, 0, 5, 512) = 8;
+SELECT h3_get_resolution_from_tile_zoom(15, 8, 0, 5, 512) = 8;


### PR DESCRIPTION
H3 grid and mercator zoom levels are scaling with a different factor and it is not always obvious how to match one to another when generating Web Mercator tiles.

Function `h3_get_resolution_from_tile_zoom` suggests a way to do it using user-defined target edge length. Useful when need to fit labels into the H3 cells. Example of usage is on disaster.ninja