### PR TITLE
Align SQL naming with DuckDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ avoid adding features or APIs which do not map onto the
   </summary>
 
 - Add `h3_get_resolution_from_tile_zoom` (see [#176], thanks [@sleeping-h])
-- Align function names with other binding (see [#177])
+- Alter function names containing `lat_lng` to `latlng` in order to align with other SQL bindings (see [#177])
 
 </details>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ avoid adding features or APIs which do not map onto the
   </summary>
 
 - Add `h3_get_resolution_from_tile_zoom` (see [#176], thanks [@sleeping-h])
+- Align function names with other binding (see [#177])
 
 </details>
 
@@ -290,6 +291,7 @@ avoid adding features or APIs which do not map onto the
 [#160]: https://github.com/zachasme/h3-pg/pull/160
 [#169]: https://github.com/zachasme/h3-pg/issues/169
 [#176]: https://github.com/zachasme/h3-pg/pull/176
+[#177]: https://github.com/zachasme/h3-pg/pull/177
 [@abelvm]: https://github.com/AbelVM
 [@bayandin]: https://github.com/bayandin
 [@BielStela]: https://github.com/BielStela

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ If the prerequisites are met you can use the [PGXN Client](docs/pgxnclient.md) t
 $ pgxn install h3
 $ pgxn load h3
 $ psql
-=# SELECT h3_lat_lng_to_cell(POINT('37.3615593,-122.0553238'), 5);
-  h3_lat_lng_to_cell
+=# SELECT h3_latlng_to_cell(POINT('37.3615593,-122.0553238'), 5);
+  h3_latlng_to_cell
 -----------------
  85e35e73fffffff
 (1 row)

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,17 +18,17 @@ represented as a (or 16-character) hexadecimal string, like '8928308280fffff'.
 These function are used for finding the H3 index containing coordinates,
 and for finding the center and boundary of H3 indexes.
 
-### h3_lat_lng_to_cell(latlng `point`, resolution `integer`) ⇒ `h3index`
-*Since v4.0.0*
+### h3_latlng_to_cell(latlng `point`, resolution `integer`) ⇒ `h3index`
+*Since vunreleased*
 
-See also: <a href="#h3_lat_lng_to_cell.geometry.resolution.integer.h3index">h3_lat_lng_to_cell(`geometry`, `integer`)</a>, <a href="#h3_lat_lng_to_cell.geography.resolution.integer.h3index">h3_lat_lng_to_cell(`geography`, `integer`)</a>
+See also: <a href="#h3_latlng_to_cell.geometry.resolution.integer.h3index">h3_latlng_to_cell(`geometry`, `integer`)</a>, <a href="#h3_latlng_to_cell.geography.resolution.integer.h3index">h3_latlng_to_cell(`geography`, `integer`)</a>
 
 
 Indexes the location at the specified resolution.
 
 
-### h3_cell_to_lat_lng(cell `h3index`) ⇒ `point`
-*Since v4.0.0*
+### h3_cell_to_latlng(cell `h3index`) ⇒ `point`
+*Since vunreleased*
 
 See also: <a href="#h3_cell_to_geometry.h3index.geometry">h3_cell_to_geometry(`h3index`)</a>, <a href="#h3_cell_to_geography.h3index.geography">h3_cell_to_geography(`h3index`)</a>
 
@@ -352,8 +352,8 @@ Returns a single vertex for a given cell, as an H3 index.
 Returns all vertexes for a given cell, as H3 indexes.
 
 
-### h3_vertex_to_lat_lng(vertex `h3index`) ⇒ `point`
-*Since v4.0.0*
+### h3_vertex_to_latlng(vertex `h3index`) ⇒ `point`
+*Since vunreleased*
 
 
 Get the geocoordinates of an H3 vertex.
@@ -521,26 +521,35 @@ Migrate h3index from pass-by-reference to pass-by-value.
 
 DEPRECATED: Use `SET h3.extend_antimeridian TO true` instead.
 
+
+DEPRECATED: Use `h3_vertex_to_latlng` instead.
+
+
+DEPRECATED: Use `h3_cell_to_latlng` instead.
+
+
+DEPRECATED: Use `h3_latlng_to_cell` instead.
+
 # PostGIS Integration
 The `GEOMETRY` data passed to `h3-pg` PostGIS functions should
 be in SRID 4326. This is an expectation of the core H3 library.
 Using other SRIDs, such as 3857, can result in either errors or
 invalid data depending on the function.
 For example, the `h3_polygon_to_cells()` function will fail with
-an error in this scenario while the `h3_lat_lng_to_cell()` function
+an error in this scenario while the `h3_latlng_to_cell()` function
 will return an invalid geometry.
 
 # PostGIS Indexing Functions
 
-### h3_lat_lng_to_cell(`geometry`, resolution `integer`) ⇒ `h3index`
-*Since v4.0.0*
+### h3_latlng_to_cell(`geometry`, resolution `integer`) ⇒ `h3index`
+*Since vunreleased*
 
 
 Indexes the location at the specified resolution.
 
 
-### h3_lat_lng_to_cell(`geography`, resolution `integer`) ⇒ `h3index`
-*Since v4.0.0*
+### h3_latlng_to_cell(`geography`, resolution `integer`) ⇒ `h3index`
+*Since vunreleased*
 
 
 Indexes the location at the specified resolution.
@@ -836,5 +845,11 @@ Returns `h3_raster_class_summary_item` for each H3 cell and value for a given ba
 
 
 Returns `h3_raster_class_summary_item` for each H3 cell and value for a given band. Attempts to select an appropriate method based on number of pixels per H3 cell.
+
+
+DEPRECATED: Use `h3_latlng_to_cell` instead..
+
+
+DEPRECATED: Use `h3_latlng_to_cell` instead..
 
 

--- a/h3/sql/install/01-indexing.sql
+++ b/h3/sql/install/01-indexing.sql
@@ -20,7 +20,7 @@
 --| and for finding the center and boundary of H3 indexes.
 
 --@ availability: unreleased
---@ ref: h3_lat_lng_to_cell_geometry, h3_lat_lng_to_cell_geography
+--@ ref: h3_latlng_to_cell_geometry, h3_latlng_to_cell_geography
 CREATE OR REPLACE FUNCTION
     h3_latlng_to_cell(latlng point, resolution integer) RETURNS h3index
 AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION

--- a/h3/sql/install/01-indexing.sql
+++ b/h3/sql/install/01-indexing.sql
@@ -19,20 +19,20 @@
 --| These function are used for finding the H3 index containing coordinates,
 --| and for finding the center and boundary of H3 indexes.
 
---@ availability: 4.0.0
+--@ availability: unreleased
 --@ ref: h3_lat_lng_to_cell_geometry, h3_lat_lng_to_cell_geography
 CREATE OR REPLACE FUNCTION
-    h3_lat_lng_to_cell(latlng point, resolution integer) RETURNS h3index
+    h3_latlng_to_cell(latlng point, resolution integer) RETURNS h3index
 AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
-    h3_lat_lng_to_cell(point, integer)
+    h3_latlng_to_cell(point, integer)
 IS 'Indexes the location at the specified resolution.';
 
---@ availability: 4.0.0
+--@ availability: unreleased
 --@ ref: h3_cell_to_geometry, h3_cell_to_geography
 CREATE OR REPLACE FUNCTION
-    h3_cell_to_lat_lng(cell h3index) RETURNS point
+    h3_cell_to_latlng(cell h3index) RETURNS point
 AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
-    h3_cell_to_lat_lng(h3index)
+    h3_cell_to_latlng(h3index)
 IS 'Finds the centroid of the index.';
 
 --@ availability: 4.0.0

--- a/h3/sql/install/07-vertex.sql
+++ b/h3/sql/install/07-vertex.sql
@@ -32,11 +32,11 @@ AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
     h3_cell_to_vertexes(cell h3index)
 IS 'Returns all vertexes for a given cell, as H3 indexes.';
 
---@ availability: 4.0.0
+--@ availability: unreleased
 CREATE OR REPLACE FUNCTION
-    h3_vertex_to_lat_lng(vertex h3index) RETURNS point
+    h3_vertex_to_latlng(vertex h3index) RETURNS point
 AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
-    h3_vertex_to_lat_lng(vertex h3index)
+    h3_vertex_to_latlng(vertex h3index)
 IS 'Get the geocoordinates of an H3 vertex.';
 
 --@ availability: 4.0.0

--- a/h3/sql/install/20-casts.sql
+++ b/h3/sql/install/20-casts.sql
@@ -32,6 +32,6 @@ CREATE CAST (bigint AS h3index) WITH FUNCTION bigint_to_h3index(bigint);
 COMMENT ON CAST (h3index AS bigint) IS
     'Convert bigint to H3 index.';
 
-CREATE CAST (h3index AS point) WITH FUNCTION h3_cell_to_lat_lng(h3index);
+CREATE CAST (h3index AS point) WITH FUNCTION h3_cell_to_latlng(h3index);
 COMMENT ON CAST (h3index AS point) IS
     'Convert H3 index to point.';

--- a/h3/sql/install/99-deprecated.sql
+++ b/h3/sql/install/99-deprecated.sql
@@ -21,3 +21,27 @@ CREATE OR REPLACE FUNCTION
 AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
     h3_cell_to_boundary(h3index, boolean)
 IS 'DEPRECATED: Use `SET h3.extend_antimeridian TO true` instead.';
+
+--@ availability: 4.0.0
+--@ deprecated
+CREATE OR REPLACE FUNCTION
+    h3_vertex_to_lat_lng(vertex h3index) RETURNS point
+AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
+    h3_vertex_to_lat_lng(vertex h3index)
+IS 'DEPRECATED: Use `h3_vertex_to_latlng` instead.';
+
+--@ availability: 4.0.0
+--@ deprecated
+CREATE OR REPLACE FUNCTION
+    h3_cell_to_lat_lng(cell h3index) RETURNS point
+AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
+    h3_cell_to_lat_lng(h3index)
+IS 'DEPRECATED: Use `h3_cell_to_latlng` instead.';
+
+--@ availability: 4.0.0
+--@ deprecated
+CREATE OR REPLACE FUNCTION
+    h3_lat_lng_to_cell(latlng point, resolution integer) RETURNS h3index
+AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
+    h3_lat_lng_to_cell(point, integer)
+IS 'DEPRECATED: Use `h3_latlng_to_cell` instead.';

--- a/h3/sql/updates/h3--4.2.2--unreleased.sql
+++ b/h3/sql/updates/h3--4.2.2--unreleased.sql
@@ -16,3 +16,41 @@
 
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "ALTER EXTENSION h3 UPDATE TO 'unreleased'" to load this file. \quit
+
+--@ availability: unreleased
+CREATE OR REPLACE FUNCTION
+    h3_vertex_to_latlng(vertex h3index) RETURNS point
+AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
+    h3_vertex_to_latlng(vertex h3index)
+IS 'Get the geocoordinates of an H3 vertex.';
+
+COMMENT ON FUNCTION
+    h3_vertex_to_lat_lng(vertex h3index)
+IS 'DEPRECATED: Use `h3_vertex_to_latlng` instead.';
+
+--@ availability: unreleased
+CREATE OR REPLACE FUNCTION
+    h3_latlng_to_cell(latlng point, resolution integer) RETURNS h3index
+AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
+    h3_latlng_to_cell(point, integer)
+IS 'Indexes the location at the specified resolution.';
+
+COMMENT ON FUNCTION
+    h3_lat_lng_to_cell(point, integer)
+IS 'DEPRECATED: Use `h3_latlng_to_cell` instead.';
+
+--@ availability: unreleased
+CREATE OR REPLACE FUNCTION
+    h3_cell_to_latlng(cell h3index) RETURNS point
+AS 'h3' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE; COMMENT ON FUNCTION
+    h3_cell_to_latlng(h3index)
+IS 'Finds the centroid of the index.';
+
+COMMENT ON FUNCTION
+    h3_cell_to_lat_lng(vertex h3index)
+IS 'DEPRECATED: Use `h3_cell_to_latlng` instead.';
+
+DROP CAST IF EXISTS (h3index AS point);
+CREATE CAST (h3index AS point) WITH FUNCTION h3_cell_to_latlng(h3index);
+COMMENT ON CAST (h3index AS point) IS
+    'Convert H3 index to point.';

--- a/h3/src/binding/indexing.c
+++ b/h3/src/binding/indexing.c
@@ -31,13 +31,13 @@
 #include "type.h"
 #include "guc.h"
 
-PGDLLEXPORT PG_FUNCTION_INFO_V1(h3_lat_lng_to_cell);
-PGDLLEXPORT PG_FUNCTION_INFO_V1(h3_cell_to_lat_lng);
+PGDLLEXPORT PG_FUNCTION_INFO_V1(h3_latlng_to_cell);
+PGDLLEXPORT PG_FUNCTION_INFO_V1(h3_cell_to_latlng);
 PGDLLEXPORT PG_FUNCTION_INFO_V1(h3_cell_to_boundary);
 
 /* Indexes the location at the specified resolution */
 Datum
-h3_lat_lng_to_cell(PG_FUNCTION_ARGS)
+h3_latlng_to_cell(PG_FUNCTION_ARGS)
 {
 	H3Index		cell;
 	LatLng		location;
@@ -71,7 +71,7 @@ h3_lat_lng_to_cell(PG_FUNCTION_ARGS)
 
 /* Finds the centroid of the index */
 Datum
-h3_cell_to_lat_lng(PG_FUNCTION_ARGS)
+h3_cell_to_latlng(PG_FUNCTION_ARGS)
 {
 	LatLng		center;
 	Point	   *point = palloc(sizeof(Point));

--- a/h3/src/binding/vertex.c
+++ b/h3/src/binding/vertex.c
@@ -27,7 +27,7 @@
 
 PGDLLEXPORT PG_FUNCTION_INFO_V1(h3_cell_to_vertex);
 PGDLLEXPORT PG_FUNCTION_INFO_V1(h3_cell_to_vertexes);
-PGDLLEXPORT PG_FUNCTION_INFO_V1(h3_vertex_to_lat_lng);
+PGDLLEXPORT PG_FUNCTION_INFO_V1(h3_vertex_to_latlng);
 PGDLLEXPORT PG_FUNCTION_INFO_V1(h3_is_valid_vertex);
 
 /* Returns a single vertex for a given cell, as an H3 index */
@@ -84,7 +84,7 @@ h3_cell_to_vertexes(PG_FUNCTION_ARGS)
 
 /* Get the geocoordinates of an H3 vertex */
 Datum
-h3_vertex_to_lat_lng(PG_FUNCTION_ARGS)
+h3_vertex_to_latlng(PG_FUNCTION_ARGS)
 {
 	H3Index		vertex = PG_GETARG_H3INDEX(0);
 

--- a/h3/src/deprecated.c
+++ b/h3/src/deprecated.c
@@ -76,3 +76,7 @@ H3_DEPRECATE("4.0.0", h3_uncompact);
 H3_DEPRECATE("4.0.0", h3_unidirectional_edge_is_valid);
 H3_DEPRECATE("4.1.0", h3_cell_to_boundary_wkb);
 H3_DEPRECATE("4.1.0", h3_cells_to_multi_polygon_wkb);
+
+H3_SOFT_DEPRECATE(h3_vertex_to_lat_lng, h3_vertex_to_latlng);
+H3_SOFT_DEPRECATE(h3_cell_to_lat_lng, h3_cell_to_latlng);
+H3_SOFT_DEPRECATE(h3_lat_lng_to_cell, h3_latlng_to_cell);

--- a/h3/test/CMakeLists.txt
+++ b/h3/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TESTS
   clustering
+  deprecated
   edge
   extension
   hierarchy

--- a/h3/test/expected/deprecated.out
+++ b/h3/test/expected/deprecated.out
@@ -1,0 +1,13 @@
+\pset tuples_only on
+-- neighbouring indexes (one hexagon, one pentagon) at resolution 3
+\set geo POINT(-144.52399108028, 49.7165031828995)
+\set hexagon '\'831c02fffffffff\'::h3index'
+\set resolution 3
+SELECT h3_cell_to_lat_lng(:hexagon) ~= :geo;
+WARNING:  Deprecation notice: h3_cell_to_lat_lng will be deprecated in favor of h3_cell_to_latlng next major release
+ t
+
+SELECT h3_lat_lng_to_cell(:geo, :resolution) = :hexagon;
+WARNING:  Deprecation notice: h3_lat_lng_to_cell will be deprecated in favor of h3_latlng_to_cell next major release
+ t
+

--- a/h3/test/expected/indexing.out
+++ b/h3/test/expected/indexing.out
@@ -6,31 +6,31 @@
 \set edgecross '\'8003fffffffffff\'::h3index'
 \set resolution 3
 --
--- TEST h3_cell_to_lat_lng and h3_lat_lng_to_cell
+-- TEST h3_cell_to_latlng and h3_latlng_to_cell
 --
 -- convertion to geo works
-SELECT h3_cell_to_lat_lng(:hexagon) ~= :geo;
+SELECT h3_cell_to_latlng(:hexagon) ~= :geo;
  t
 
 -- convertion to h3 index works
-SELECT h3_lat_lng_to_cell(:geo, :resolution) = :hexagon;
+SELECT h3_latlng_to_cell(:geo, :resolution) = :hexagon;
  t
 
--- h3_cell_to_lat_lng is inverse of h3_lat_lng_to_cell
-SELECT h3_cell_to_lat_lng(i) ~= :geo AND h3_get_resolution(i) = :resolution FROM (
-    SELECT h3_lat_lng_to_cell(:geo, :resolution) AS i
+-- h3_cell_to_latlng is inverse of h3_latlng_to_cell
+SELECT h3_cell_to_latlng(i) ~= :geo AND h3_get_resolution(i) = :resolution FROM (
+    SELECT h3_latlng_to_cell(:geo, :resolution) AS i
 ) AS q;
  t
 
--- h3_lat_lng_to_cell is inverse of h3_cell_to_lat_lng
-SELECT h3_lat_lng_to_cell(g, r) = :hexagon FROM (
-    SELECT h3_cell_to_lat_lng(:hexagon) AS g, h3_get_resolution(:hexagon) AS r
+-- h3_latlng_to_cell is inverse of h3_cell_to_latlng
+SELECT h3_latlng_to_cell(g, r) = :hexagon FROM (
+    SELECT h3_cell_to_latlng(:hexagon) AS g, h3_get_resolution(:hexagon) AS r
 ) AS q;
  t
 
 -- same for pentagon
-SELECT h3_lat_lng_to_cell(g, r) = :pentagon FROM (
-    SELECT h3_cell_to_lat_lng(:pentagon) AS g, h3_get_resolution(:pentagon) AS r
+SELECT h3_latlng_to_cell(g, r) = :pentagon FROM (
+    SELECT h3_cell_to_latlng(:pentagon) AS g, h3_get_resolution(:pentagon) AS r
 ) AS q;
  t
 
@@ -48,8 +48,8 @@ SELECT h3_polygon_to_cells(h3_cell_to_boundary(:pentagon), null, :resolution) = 
 -- the boundary of an edgecrossing index is different with flag set to true
 SELECT h3_cell_to_boundary(:hexagon) ~= h3_cell_to_boundary(:hexagon, true)
 AND NOT h3_cell_to_boundary(:edgecross) ~= h3_cell_to_boundary(:edgecross, true);
-WARNING:  Deprecated: Please use `SET h3.extend_antimeridian TO true` instead of extend flag
-WARNING:  Deprecated: Please use `SET h3.extend_antimeridian TO true` instead of extend flag
+WARNING:  Deprecation notice: Please use `SET h3.extend_antimeridian TO true` instead of extend flag
+WARNING:  Deprecation notice: Please use `SET h3.extend_antimeridian TO true` instead of extend flag
  t
 
 -- cell to parent RES_MISMATCH

--- a/h3/test/expected/miscellaneous.out
+++ b/h3/test/expected/miscellaneous.out
@@ -37,17 +37,17 @@ SELECT h3_get_hexagon_area_avg(10, 'km') = h3_get_hexagon_area_avg(10);
 -- TEST h3_cell_area
 --
 \set expected_km2 0.01119834221989390
-SELECT abs((h3_cell_area(h3_lat_lng_to_cell(POINT(0, 0), 10), 'm^2') / 1000000) - :expected_km2) < :epsilon;
+SELECT abs((h3_cell_area(h3_latlng_to_cell(POINT(0, 0), 10), 'm^2') / 1000000) - :expected_km2) < :epsilon;
  t
 
-SELECT abs(h3_cell_area(h3_lat_lng_to_cell(POINT(0, 0), 10), 'km^2') - :expected_km2) < :epsilon;
+SELECT abs(h3_cell_area(h3_latlng_to_cell(POINT(0, 0), 10), 'km^2') - :expected_km2) < :epsilon;
  t
 
-SELECT h3_cell_area(h3_lat_lng_to_cell(POINT(0, 0), 10), 'rads^2') > 0;
+SELECT h3_cell_area(h3_latlng_to_cell(POINT(0, 0), 10), 'rads^2') > 0;
  t
 
 -- default is km^2
-SELECT h3_cell_area(h3_lat_lng_to_cell(POINT(0, 0), 10), 'km^2') = h3_cell_area(h3_lat_lng_to_cell(POINT(0, 0), 10));
+SELECT h3_cell_area(h3_latlng_to_cell(POINT(0, 0), 10), 'km^2') = h3_cell_area(h3_latlng_to_cell(POINT(0, 0), 10));
  t
 
 --

--- a/h3/test/expected/vertex.out
+++ b/h3/test/expected/vertex.out
@@ -23,10 +23,10 @@ SELECT COUNT(*) = 5 FROM (
  t
 
 --
--- TEST h3_vertex_to_lat_lng
+-- TEST h3_vertex_to_latlng
 --
  
-SELECT h3_vertex_to_lat_lng(:vertex2) ~= :geo;
+SELECT h3_vertex_to_latlng(:vertex2) ~= :geo;
  t
 
 --

--- a/h3/test/sql/deprecated.sql
+++ b/h3/test/sql/deprecated.sql
@@ -1,0 +1,9 @@
+\pset tuples_only on
+
+-- neighbouring indexes (one hexagon, one pentagon) at resolution 3
+\set geo POINT(-144.52399108028, 49.7165031828995)
+\set hexagon '\'831c02fffffffff\'::h3index'
+\set resolution 3
+
+SELECT h3_cell_to_lat_lng(:hexagon) ~= :geo;
+SELECT h3_lat_lng_to_cell(:geo, :resolution) = :hexagon;

--- a/h3/test/sql/deprecated.sql
+++ b/h3/test/sql/deprecated.sql
@@ -5,5 +5,10 @@
 \set hexagon '\'831c02fffffffff\'::h3index'
 \set resolution 3
 
+SELECT h3_cell_to_lat_lng(:hexagon);
+SELECT :geo;
+SELECT h3_lat_lng_to_cell(:geo, :resolution);
+SELECT :hexagon;
+
 SELECT h3_cell_to_lat_lng(:hexagon) ~= :geo;
 SELECT h3_lat_lng_to_cell(:geo, :resolution) = :hexagon;

--- a/h3/test/sql/deprecated.sql
+++ b/h3/test/sql/deprecated.sql
@@ -5,10 +5,5 @@
 \set hexagon '\'831c02fffffffff\'::h3index'
 \set resolution 3
 
-SELECT h3_cell_to_lat_lng(:hexagon);
-SELECT :geo;
-SELECT h3_lat_lng_to_cell(:geo, :resolution);
-SELECT :hexagon;
-
 SELECT h3_cell_to_lat_lng(:hexagon) ~= :geo;
 SELECT h3_lat_lng_to_cell(:geo, :resolution) = :hexagon;

--- a/h3/test/sql/indexing.sql
+++ b/h3/test/sql/indexing.sql
@@ -8,26 +8,26 @@
 \set resolution 3
 
 --
--- TEST h3_cell_to_lat_lng and h3_lat_lng_to_cell
+-- TEST h3_cell_to_latlng and h3_latlng_to_cell
 --
 
 -- convertion to geo works
-SELECT h3_cell_to_lat_lng(:hexagon) ~= :geo;
+SELECT h3_cell_to_latlng(:hexagon) ~= :geo;
 
 -- convertion to h3 index works
-SELECT h3_lat_lng_to_cell(:geo, :resolution) = :hexagon;
+SELECT h3_latlng_to_cell(:geo, :resolution) = :hexagon;
 
--- h3_cell_to_lat_lng is inverse of h3_lat_lng_to_cell
-SELECT h3_cell_to_lat_lng(i) ~= :geo AND h3_get_resolution(i) = :resolution FROM (
-    SELECT h3_lat_lng_to_cell(:geo, :resolution) AS i
+-- h3_cell_to_latlng is inverse of h3_latlng_to_cell
+SELECT h3_cell_to_latlng(i) ~= :geo AND h3_get_resolution(i) = :resolution FROM (
+    SELECT h3_latlng_to_cell(:geo, :resolution) AS i
 ) AS q;
--- h3_lat_lng_to_cell is inverse of h3_cell_to_lat_lng
-SELECT h3_lat_lng_to_cell(g, r) = :hexagon FROM (
-    SELECT h3_cell_to_lat_lng(:hexagon) AS g, h3_get_resolution(:hexagon) AS r
+-- h3_latlng_to_cell is inverse of h3_cell_to_latlng
+SELECT h3_latlng_to_cell(g, r) = :hexagon FROM (
+    SELECT h3_cell_to_latlng(:hexagon) AS g, h3_get_resolution(:hexagon) AS r
 ) AS q;
 -- same for pentagon
-SELECT h3_lat_lng_to_cell(g, r) = :pentagon FROM (
-    SELECT h3_cell_to_lat_lng(:pentagon) AS g, h3_get_resolution(:pentagon) AS r
+SELECT h3_latlng_to_cell(g, r) = :pentagon FROM (
+    SELECT h3_cell_to_latlng(:pentagon) AS g, h3_get_resolution(:pentagon) AS r
 ) AS q;
 
 --

--- a/h3/test/sql/miscellaneous.sql
+++ b/h3/test/sql/miscellaneous.sql
@@ -30,12 +30,12 @@ SELECT h3_get_hexagon_area_avg(10, 'km') = h3_get_hexagon_area_avg(10);
 --
 
 \set expected_km2 0.01119834221989390
-SELECT abs((h3_cell_area(h3_lat_lng_to_cell(POINT(0, 0), 10), 'm^2') / 1000000) - :expected_km2) < :epsilon;
-SELECT abs(h3_cell_area(h3_lat_lng_to_cell(POINT(0, 0), 10), 'km^2') - :expected_km2) < :epsilon;
-SELECT h3_cell_area(h3_lat_lng_to_cell(POINT(0, 0), 10), 'rads^2') > 0;
+SELECT abs((h3_cell_area(h3_latlng_to_cell(POINT(0, 0), 10), 'm^2') / 1000000) - :expected_km2) < :epsilon;
+SELECT abs(h3_cell_area(h3_latlng_to_cell(POINT(0, 0), 10), 'km^2') - :expected_km2) < :epsilon;
+SELECT h3_cell_area(h3_latlng_to_cell(POINT(0, 0), 10), 'rads^2') > 0;
 
 -- default is km^2
-SELECT h3_cell_area(h3_lat_lng_to_cell(POINT(0, 0), 10), 'km^2') = h3_cell_area(h3_lat_lng_to_cell(POINT(0, 0), 10));
+SELECT h3_cell_area(h3_latlng_to_cell(POINT(0, 0), 10), 'km^2') = h3_cell_area(h3_latlng_to_cell(POINT(0, 0), 10));
 
 --
 -- TEST h3_get_hexagon_edge_length_avg

--- a/h3/test/sql/vertex.sql
+++ b/h3/test/sql/vertex.sql
@@ -24,10 +24,10 @@ SELECT COUNT(*) = 5 FROM (
 ) q;
 
 --
--- TEST h3_vertex_to_lat_lng
+-- TEST h3_vertex_to_latlng
 --
  
-SELECT h3_vertex_to_lat_lng(:vertex2) ~= :geo;
+SELECT h3_vertex_to_latlng(:vertex2) ~= :geo;
 
 --
 -- TEST h3_is_valid_vertex and

--- a/h3_postgis/sql/install/01-indexing.sql
+++ b/h3_postgis/sql/install/01-indexing.sql
@@ -19,31 +19,31 @@
 --| Using other SRIDs, such as 3857, can result in either errors or
 --| invalid data depending on the function.
 --| For example, the `h3_polygon_to_cells()` function will fail with
---| an error in this scenario while the `h3_lat_lng_to_cell()` function
+--| an error in this scenario while the `h3_latlng_to_cell()` function
 --| will return an invalid geometry.
 
 --| # PostGIS Indexing Functions
 
---@ availability: 4.0.0
---@ refid: h3_lat_lng_to_cell_geometry
-CREATE OR REPLACE FUNCTION h3_lat_lng_to_cell(geometry, resolution integer) RETURNS h3index
-    AS $$ SELECT h3_lat_lng_to_cell($1::point, $2); $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
+--@ availability: unreleased
+--@ refid: h3_latlng_to_cell_geometry
+CREATE OR REPLACE FUNCTION h3_latlng_to_cell(geometry, resolution integer) RETURNS h3index
+    AS $$ SELECT h3_latlng_to_cell($1::point, $2); $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
 COMMENT ON FUNCTION
-    h3_lat_lng_to_cell(geometry, resolution integer)
+    h3_latlng_to_cell(geometry, resolution integer)
 IS 'Indexes the location at the specified resolution.';
 
---@ availability: 4.0.0
---@ refid: h3_lat_lng_to_cell_geography
-CREATE OR REPLACE FUNCTION h3_lat_lng_to_cell(geography, resolution integer) RETURNS h3index
-    AS $$ SELECT h3_lat_lng_to_cell($1::geometry, $2); $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
+--@ availability: unreleased
+--@ refid: h3_latlng_to_cell_geography
+CREATE OR REPLACE FUNCTION h3_latlng_to_cell(geography, resolution integer) RETURNS h3index
+    AS $$ SELECT h3_latlng_to_cell($1::geometry, $2); $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
 COMMENT ON FUNCTION
-    h3_lat_lng_to_cell(geometry, resolution integer)
+    h3_latlng_to_cell(geometry, resolution integer)
 IS 'Indexes the location at the specified resolution.';
 
 --@ availability: 4.0.0
 --@ refid: h3_cell_to_geometry
 CREATE OR REPLACE FUNCTION h3_cell_to_geometry(h3index) RETURNS geometry
-  AS $$ SELECT ST_SetSRID(h3_cell_to_lat_lng($1)::geometry, 4326) $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
+  AS $$ SELECT ST_SetSRID(h3_cell_to_latlng($1)::geometry, 4326) $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
 COMMENT ON FUNCTION
     h3_cell_to_geometry(h3index)
 IS 'Finds the centroid of the index.';

--- a/h3_postgis/sql/install/03-traversal.sql
+++ b/h3_postgis/sql/install/03-traversal.sql
@@ -42,7 +42,7 @@ BEGIN
                     h3_cell_to_geometry(destination) AS g2),
             cells AS (
                 SELECT
-                    h3_lat_lng_to_cell(
+                    h3_latlng_to_cell(
                         ST_Centroid(ST_MakeLine(g1, g2)::geography),
                         h3_get_resolution(origin)) AS middle
                 FROM points)

--- a/h3_postgis/sql/install/10-operators.sql
+++ b/h3_postgis/sql/install/10-operators.sql
@@ -18,7 +18,7 @@
 
 --@ availability: 4.1.3
 CREATE OPERATOR @ (
-    PROCEDURE = h3_lat_lng_to_cell,
+    PROCEDURE = h3_latlng_to_cell,
     LEFTARG = geometry, RIGHTARG = integer
 );
 COMMENT ON OPERATOR @ (geometry, integer) IS
@@ -26,7 +26,7 @@ COMMENT ON OPERATOR @ (geometry, integer) IS
 
 --@ availability: 4.1.3
 CREATE OPERATOR @ (
-    PROCEDURE = h3_lat_lng_to_cell,
+    PROCEDURE = h3_latlng_to_cell,
     LEFTARG = geography, RIGHTARG = integer
 );
 COMMENT ON OPERATOR @ (geography, integer) IS

--- a/h3_postgis/sql/install/40-rasters.sql
+++ b/h3_postgis/sql/install/40-rasters.sql
@@ -60,7 +60,7 @@ CREATE OR REPLACE FUNCTION __h3_raster_polygon_centroid_cell(
 RETURNS h3index
 AS $$
 DECLARE
-    cell h3index := h3_lat_lng_to_cell(ST_Transform(ST_Centroid(poly), 4326), resolution);
+    cell h3index := h3_latlng_to_cell(ST_Transform(ST_Centroid(poly), 4326), resolution);
 BEGIN
     IF h3_is_pentagon(cell) THEN
         SELECT h3 INTO cell FROM h3_grid_disk(cell) AS h3 WHERE h3 != cell LIMIT 1;
@@ -323,7 +323,7 @@ CREATE OR REPLACE FUNCTION h3_raster_summary_centroids(
 RETURNS TABLE (h3 h3index, stats h3_raster_summary_stats)
 AS $$
     SELECT
-        h3_lat_lng_to_cell(ST_Transform(geom, 4326), resolution) AS h3,
+        h3_latlng_to_cell(ST_Transform(geom, 4326), resolution) AS h3,
         ROW(
             count(val),
             sum(val),
@@ -596,7 +596,7 @@ CREATE OR REPLACE FUNCTION __h3_raster_class_summary_centroids(
 RETURNS TABLE (h3 h3index, val integer, summary h3_raster_class_summary_item)
 AS $$
     SELECT
-        h3_lat_lng_to_cell(ST_Transform(geom, 4326), resolution) AS h3,
+        h3_latlng_to_cell(ST_Transform(geom, 4326), resolution) AS h3,
         val::integer AS val,
         ROW(
             val::integer,

--- a/h3_postgis/sql/install/99-deprecated.sql
+++ b/h3_postgis/sql/install/99-deprecated.sql
@@ -23,3 +23,19 @@ CREATE OR REPLACE FUNCTION h3_cell_to_boundary_geometry(h3index, extend_antimeri
 --@ deprecated
 CREATE OR REPLACE FUNCTION h3_cell_to_boundary_geography(h3index, extend_antimeridian boolean) RETURNS geography
   AS $$ SELECT ST_SetSRID(h3_cell_to_boundary($1, extend_antimeridian)::geometry, 4326) $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
+
+--@ availability: 4.0.0
+--@ deprecated
+CREATE OR REPLACE FUNCTION h3_lat_lng_to_cell(geometry, resolution integer) RETURNS h3index
+    AS $$ SELECT h3_lat_lng_to_cell($1::point, $2); $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
+COMMENT ON FUNCTION
+    h3_lat_lng_to_cell(geometry, resolution integer)
+IS 'DEPRECATED: Use `h3_latlng_to_cell` instead..';
+
+--@ availability: 4.0.0
+--@ deprecated
+CREATE OR REPLACE FUNCTION h3_lat_lng_to_cell(geography, resolution integer) RETURNS h3index
+    AS $$ SELECT h3_lat_lng_to_cell($1::geometry, $2); $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
+COMMENT ON FUNCTION
+    h3_lat_lng_to_cell(geometry, resolution integer)
+IS 'DEPRECATED: Use `h3_latlng_to_cell` instead..';

--- a/h3_postgis/sql/updates/h3_postgis--4.2.2--unreleased.sql
+++ b/h3_postgis/sql/updates/h3_postgis--4.2.2--unreleased.sql
@@ -46,3 +46,141 @@ $$ LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;
 COMMENT ON FUNCTION
     h3_get_resolution_from_tile_zoom(integer, integer, integer, integer, integer)
 IS 'Returns the optimal H3 resolution for a specified XYZ tile zoom level, based on hexagon size in pixels and resolution limits';
+
+-- deprecations
+
+CREATE OR REPLACE FUNCTION h3_latlng_to_cell(geometry, resolution integer) RETURNS h3index
+    AS $$ SELECT h3_latlng_to_cell($1::point, $2); $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
+COMMENT ON FUNCTION
+    h3_latlng_to_cell(geometry, resolution integer)
+IS 'Indexes the location at the specified resolution.';
+
+CREATE OR REPLACE FUNCTION h3_latlng_to_cell(geography, resolution integer) RETURNS h3index
+    AS $$ SELECT h3_latlng_to_cell($1::geometry, $2); $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
+COMMENT ON FUNCTION
+    h3_latlng_to_cell(geometry, resolution integer)
+IS 'Indexes the location at the specified resolution.';
+
+COMMENT ON FUNCTION
+    h3_lat_lng_to_cell(geometry, resolution integer)
+IS 'DEPRECATED: Use `h3_latlng_to_cell` instead..';
+
+COMMENT ON FUNCTION
+    h3_lat_lng_to_cell(geometry, resolution integer)
+IS 'DEPRECATED: Use `h3_latlng_to_cell` instead..';
+
+-- deprecations/indexing
+
+CREATE OR REPLACE FUNCTION h3_cell_to_geometry(h3index) RETURNS geometry
+  AS $$ SELECT ST_SetSRID(h3_cell_to_latlng($1)::geometry, 4326) $$ IMMUTABLE STRICT PARALLEL SAFE LANGUAGE SQL;
+
+-- deprecations/traversal
+CREATE OR REPLACE FUNCTION
+    h3_grid_path_cells_recursive(origin h3index, destination h3index) RETURNS SETOF h3index
+AS $$
+BEGIN
+    IF (SELECT
+            origin != destination
+            AND NOT h3_are_neighbor_cells(origin, destination)
+            AND ((base1 != base2 AND NOT h3_are_neighbor_cells(base1, base2))
+                OR ((h3_is_pentagon(base1) OR h3_is_pentagon(base2))
+                    AND NOT (
+                        h3_get_icosahedron_faces(origin)
+                        && h3_get_icosahedron_faces(destination))))
+        FROM (
+            SELECT
+                h3_cell_to_parent(origin, 0) AS base1,
+                h3_cell_to_parent(destination, 0) AS base2) AS t)
+    THEN
+        RETURN QUERY WITH
+            points AS (
+                SELECT
+                    h3_cell_to_geometry(origin) AS g1,
+                    h3_cell_to_geometry(destination) AS g2),
+            cells AS (
+                SELECT
+                    h3_latlng_to_cell(
+                        ST_Centroid(ST_MakeLine(g1, g2)::geography),
+                        h3_get_resolution(origin)) AS middle
+                FROM points)
+            SELECT h3_grid_path_cells_recursive(origin, middle) FROM cells
+            UNION
+            SELECT h3_grid_path_cells_recursive(middle, destination) FROM cells;
+    ELSE
+        RETURN QUERY SELECT h3_grid_path_cells(origin, destination);
+    END IF;
+END;
+$$ LANGUAGE 'plpgsql' IMMUTABLE STRICT PARALLEL SAFE;
+
+-- deprecations/operators
+DROP OPERATOR @ (geometry, integer);
+CREATE OPERATOR @ (
+    PROCEDURE = h3_latlng_to_cell,
+    LEFTARG = geometry, RIGHTARG = integer
+);
+COMMENT ON OPERATOR @ (geometry, integer) IS
+  'Index geometry at specified resolution.';
+
+DROP OPERATOR @ (geography, integer);
+CREATE OPERATOR @ (
+    PROCEDURE = h3_latlng_to_cell,
+    LEFTARG = geography, RIGHTARG = integer
+);
+COMMENT ON OPERATOR @ (geography, integer) IS
+  'Index geography at specified resolution.';
+
+-- depracations/rasters
+
+CREATE OR REPLACE FUNCTION __h3_raster_polygon_centroid_cell(
+    poly geometry,
+    resolution integer)
+RETURNS h3index
+AS $$
+DECLARE
+    cell h3index := h3_latlng_to_cell(ST_Transform(ST_Centroid(poly), 4326), resolution);
+BEGIN
+    IF h3_is_pentagon(cell) THEN
+        SELECT h3 INTO cell FROM h3_grid_disk(cell) AS h3 WHERE h3 != cell LIMIT 1;
+    END IF;
+    RETURN cell;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION h3_raster_summary_centroids(
+    rast raster,
+    resolution integer,
+    nband integer DEFAULT 1)
+RETURNS TABLE (h3 h3index, stats h3_raster_summary_stats)
+AS $$
+    SELECT
+        h3_latlng_to_cell(ST_Transform(geom, 4326), resolution) AS h3,
+        ROW(
+            count(val),
+            sum(val),
+            avg(val),
+            stddev_pop(val),
+            min(val),
+            max(val)
+        )::h3_raster_summary_stats AS stats
+    FROM ST_PixelAsCentroids(rast, nband)
+    GROUP BY 1;
+$$ LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OR REPLACE FUNCTION __h3_raster_class_summary_centroids(
+    rast raster,
+    resolution integer,
+    nband integer,
+    pixel_area double precision)
+RETURNS TABLE (h3 h3index, val integer, summary h3_raster_class_summary_item)
+AS $$
+    SELECT
+        h3_latlng_to_cell(ST_Transform(geom, 4326), resolution) AS h3,
+        val::integer AS val,
+        ROW(
+            val::integer,
+            count(*)::double precision,
+            count(*) * pixel_area
+        )::h3_raster_class_summary_item AS summary
+    FROM ST_PixelAsCentroids(rast, nband)
+    GROUP BY 1, 2;
+$$ LANGUAGE SQL IMMUTABLE PARALLEL SAFE;

--- a/h3_postgis/test/CMakeLists.txt
+++ b/h3_postgis/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TESTS
+  deprecations
   postgis
   rasters
 )

--- a/h3_postgis/test/expected/deprecations.out
+++ b/h3_postgis/test/expected/deprecations.out
@@ -1,0 +1,12 @@
+\pset tuples_only on
+\set resolution 10
+\set hexagon '\'8a63a9a99047fff\''
+\set degree ST_SetSRID(ST_Point(55.6677199224442,12.592131261648213), 4326)
+SELECT h3_lat_lng_to_cell(:degree, :resolution) = '8a63a9a99047fff';
+WARNING:  Deprecation notice: h3_lat_lng_to_cell will be deprecated in favor of h3_latlng_to_cell next major release
+ t
+
+SELECT h3_lat_lng_to_cell(h3_cell_to_geometry(:hexagon), :resolution) = '8a63a9a99047fff';
+WARNING:  Deprecation notice: h3_lat_lng_to_cell will be deprecated in favor of h3_latlng_to_cell next major release
+ t
+

--- a/h3_postgis/test/expected/postgis.out
+++ b/h3_postgis/test/expected/postgis.out
@@ -17,26 +17,26 @@
 \set transmeridianWithHoles '\'POLYGON((-170 12.5, 170 12.5, 170 7.5, -175 7.5, -175 2.5, 170 2.5, 170 -12.5, -170 -12.5, -170 -7.5, 175 -7.5, 175 -2.5, -170 -2.5, -170 12.5), (-176 11.5, -179 11.5, -179 8.5, -176 8.5, -176 11.5), (174 11.5, 171 11.5, 171 8.5, 174 8.5, 174 11.5), (174 -3.5, 171 -3.5, 171 -6.5, 174 -6.5, 174 -3.5),(-176 -8.5, -179 -8.5, -179 -11.5, -176 -11.5, -176 -8.5))\''::geometry(POLYGON)
 -- multipolygon with 2 polygons: one crossing and one not crossing antimeridian
 \set transmeridianMulti '\'MULTIPOLYGON(((-175 50, -175 55, 175 55, 175 50, -175 50)), ((170 50, 170 55, 165 55, 165 50, 170 50)))\''::geometry(MULTIPOLYGON)
-SELECT h3_lat_lng_to_cell(:degree, :resolution) = '8a63a9a99047fff';
+SELECT h3_latlng_to_cell(:degree, :resolution) = '8a63a9a99047fff';
  t
 
 -- meters are NOT reprojected
-SELECT h3_lat_lng_to_cell(:meter, :resolution) <> '8a63a9a99047fff';
+SELECT h3_latlng_to_cell(:meter, :resolution) <> '8a63a9a99047fff';
  t
 
 -- check back/forth conversion return same hex
-SELECT h3_lat_lng_to_cell(h3_cell_to_geometry(:hexagon), :resolution) = '8a63a9a99047fff';
+SELECT h3_latlng_to_cell(h3_cell_to_geometry(:hexagon), :resolution) = '8a63a9a99047fff';
  t
 
 -- check num points in boundary
 SELECT ST_NPoints(h3_cell_to_boundary_geometry(:hexagon)) = 7;
  t
 
--- test strict h3_lat_lng_to_cell throws for bad latlon
+-- test strict h3_latlng_to_cell throws for bad latlon
 CREATE FUNCTION h3_test_postgis_nounit() RETURNS boolean LANGUAGE PLPGSQL
     AS $$
         BEGIN
-            PERFORM h3_lat_lng_to_cell(POINT(360, 2.592131261648213), 1);
+            PERFORM h3_latlng_to_cell(POINT(360, 2.592131261648213), 1);
             RETURN false;
         EXCEPTION WHEN OTHERS THEN
             RETURN true;
@@ -51,12 +51,12 @@ DROP FUNCTION h3_test_postgis_nounit;
 -- Test wraparound
 \set lon 55.6677199224442
 \set lat 12.592131261648213
-SELECT h3_lat_lng_to_cell(POINT(:lon,       :lat), 7)
-     = h3_lat_lng_to_cell(POINT(:lon + 360, :lat), 7);
+SELECT h3_latlng_to_cell(POINT(:lon,       :lat), 7)
+     = h3_latlng_to_cell(POINT(:lon + 360, :lat), 7);
  t
 
-SELECT h3_lat_lng_to_cell(POINT(:lon, :lat      ), 7)
-     = h3_lat_lng_to_cell(POINT(:lon, :lat + 360), 7);
+SELECT h3_latlng_to_cell(POINT(:lon, :lat      ), 7)
+     = h3_latlng_to_cell(POINT(:lon, :lat + 360), 7);
  t
 
 -- test h3_grid_path_cells_recursive works for long path

--- a/h3_postgis/test/expected/rasters.out
+++ b/h3_postgis/test/expected/rasters.out
@@ -132,7 +132,7 @@ WITH
         -- Find an H3 cell in a bottom-right corner of a first raster
         -- (intersecting 4 rasters)
         SELECT
-            h3_lat_lng_to_cell(
+            h3_latlng_to_cell(
                 ST_MakePoint(
                     ST_RasterToWorldCoordX(rast, :raster_size),
                     ST_RasterToWorldCoordY(rast, :raster_size)),

--- a/h3_postgis/test/sql/deprecations.sql
+++ b/h3_postgis/test/sql/deprecations.sql
@@ -1,0 +1,7 @@
+\pset tuples_only on
+\set resolution 10
+\set hexagon '\'8a63a9a99047fff\''
+\set degree ST_SetSRID(ST_Point(55.6677199224442,12.592131261648213), 4326)
+
+SELECT h3_lat_lng_to_cell(:degree, :resolution) = '8a63a9a99047fff';
+SELECT h3_lat_lng_to_cell(h3_cell_to_geometry(:hexagon), :resolution) = '8a63a9a99047fff';

--- a/h3_postgis/test/sql/postgis.sql
+++ b/h3_postgis/test/sql/postgis.sql
@@ -19,22 +19,22 @@
 \set transmeridianMulti '\'MULTIPOLYGON(((-175 50, -175 55, 175 55, 175 50, -175 50)), ((170 50, 170 55, 165 55, 165 50, 170 50)))\''::geometry(MULTIPOLYGON)
 
 
-SELECT h3_lat_lng_to_cell(:degree, :resolution) = '8a63a9a99047fff';
+SELECT h3_latlng_to_cell(:degree, :resolution) = '8a63a9a99047fff';
 
 -- meters are NOT reprojected
-SELECT h3_lat_lng_to_cell(:meter, :resolution) <> '8a63a9a99047fff';
+SELECT h3_latlng_to_cell(:meter, :resolution) <> '8a63a9a99047fff';
 
 -- check back/forth conversion return same hex
-SELECT h3_lat_lng_to_cell(h3_cell_to_geometry(:hexagon), :resolution) = '8a63a9a99047fff';
+SELECT h3_latlng_to_cell(h3_cell_to_geometry(:hexagon), :resolution) = '8a63a9a99047fff';
 
 -- check num points in boundary
 SELECT ST_NPoints(h3_cell_to_boundary_geometry(:hexagon)) = 7;
 
--- test strict h3_lat_lng_to_cell throws for bad latlon
+-- test strict h3_latlng_to_cell throws for bad latlon
 CREATE FUNCTION h3_test_postgis_nounit() RETURNS boolean LANGUAGE PLPGSQL
     AS $$
         BEGIN
-            PERFORM h3_lat_lng_to_cell(POINT(360, 2.592131261648213), 1);
+            PERFORM h3_latlng_to_cell(POINT(360, 2.592131261648213), 1);
             RETURN false;
         EXCEPTION WHEN OTHERS THEN
             RETURN true;
@@ -48,11 +48,11 @@ DROP FUNCTION h3_test_postgis_nounit;
 -- Test wraparound
 \set lon 55.6677199224442
 \set lat 12.592131261648213
-SELECT h3_lat_lng_to_cell(POINT(:lon,       :lat), 7)
-     = h3_lat_lng_to_cell(POINT(:lon + 360, :lat), 7);
+SELECT h3_latlng_to_cell(POINT(:lon,       :lat), 7)
+     = h3_latlng_to_cell(POINT(:lon + 360, :lat), 7);
 
-SELECT h3_lat_lng_to_cell(POINT(:lon, :lat      ), 7)
-     = h3_lat_lng_to_cell(POINT(:lon, :lat + 360), 7);
+SELECT h3_latlng_to_cell(POINT(:lon, :lat      ), 7)
+     = h3_latlng_to_cell(POINT(:lon, :lat + 360), 7);
 
 -- test h3_grid_path_cells_recursive works for long path
 SELECT COUNT(*) > 0 FROM (

--- a/h3_postgis/test/sql/rasters.sql
+++ b/h3_postgis/test/sql/rasters.sql
@@ -136,7 +136,7 @@ WITH
         -- Find an H3 cell in a bottom-right corner of a first raster
         -- (intersecting 4 rasters)
         SELECT
-            h3_lat_lng_to_cell(
+            h3_latlng_to_cell(
                 ST_MakePoint(
                     ST_RasterToWorldCoordX(rast, :raster_size),
                     ST_RasterToWorldCoordY(rast, :raster_size)),

--- a/include/deprecate.h
+++ b/include/deprecate.h
@@ -18,6 +18,8 @@
 
 #include <fmgr.h> // PG_FUNCTION_INFO_V1
 
+#include "error.h"
+
 /*	Inspired by PostGIS legacy function handling */
 /*	https://github.com/postgis/postgis/blob/master/postgis/postgis_legacy.c */
 
@@ -34,4 +36,13 @@
 			errhint("Consider running: ALTER EXTENSION h3 UPDATE") \
 		)); \
 		PG_RETURN_POINTER(NULL); \
+	}
+
+#define H3_SOFT_DEPRECATE(oldfunc, newfunc) \
+	Datum newfunc(PG_FUNCTION_ARGS); \
+	PGDLLEXPORT PG_FUNCTION_INFO_V1(oldfunc); \
+	Datum oldfunc(PG_FUNCTION_ARGS) \
+	{ \
+		H3_DEPRECATION(#oldfunc " will be deprecated in favor of " #newfunc " next major release"); \
+		newfunc(fcinfo); \
 	}

--- a/include/deprecate.h
+++ b/include/deprecate.h
@@ -44,5 +44,5 @@
 	Datum oldfunc(PG_FUNCTION_ARGS) \
 	{ \
 		H3_DEPRECATION(#oldfunc " will be deprecated in favor of " #newfunc " next major release"); \
-		newfunc(fcinfo); \
+		return newfunc(fcinfo); \
 	}

--- a/include/error.h
+++ b/include/error.h
@@ -35,7 +35,7 @@ void h3_assert(int error);
 
 #define H3_DEPRECATION(msg)			  \
 	ereport(WARNING, (				  \
-		errmsg("Deprecated: %s", msg) \
+		errmsg("Deprecation notice: %s", msg) \
 	))
 
 #define DEBUG(msg, ...)			   \


### PR DESCRIPTION
It would be nice to align SQL binding function naming across dialects.

See https://github.com/uber/h3/pull/1005#discussion_r2074656959.

This PR alters function names containing `lat_lng` to `latlng` through a soft-deprecation warning.

Closes #175